### PR TITLE
Session: fixed warning when cookie 'nette-browser' contained an array

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -122,7 +122,7 @@ class Session extends Nette\Object
 
 		// browser closing detection
 		$browserKey = $this->request->getCookie('nette-browser');
-		if (!$browserKey) {
+		if (!is_string($browserKey) || !preg_match('#^[0-9a-z]{10}\z#', $browserKey)) {
 			$browserKey = Nette\Utils\Random::generate();
 		}
 		$browserClosed = !isset($nf['B']) || $nf['B'] !== $browserKey;

--- a/tests/Http/Session.netteCookie.phpt
+++ b/tests/Http/Session.netteCookie.phpt
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Test: Nette\Http\Session error caused by a malicious 'nette-browser' cookie
+ */
+
+use Nette\Http\Session,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+class MockResponse extends Nette\Http\Response
+{
+	public function setCookie($name, $value, $time, $path = NULL, $domain = NULL, $secure = NULL, $httpOnly = NULL)
+	{
+		Assert::type('string', $value);
+		return parent::setCookie($name, $value, $time, $path, $domain, $secure, $httpOnly);
+	}
+}
+
+
+$_COOKIE['nette-browser'] = array('invalid');
+
+$requestFactory = new Nette\Http\RequestFactory();
+$request = $requestFactory->createHttpRequest();
+
+$session = new Session($request, new MockResponse);
+$session->start();


### PR DESCRIPTION
Setting cookie `nette-browser[]` will trigger a warning on any nette web which uses sessions.
