### PR TITLE
Session calls undefined method IResponse::removeDuplicateCookies()

### DIFF
--- a/src/Http/IResponse.php
+++ b/src/Http/IResponse.php
@@ -131,4 +131,11 @@ interface IResponse
 	 */
 	function deleteCookie($name, $path = NULL, $domain = NULL, $secure = NULL);
 
+	/**
+	 * Removes duplicate cookies from response.
+	 * @return void
+	 * @internal
+	 */
+	function removeDuplicateCookies()
+
 }


### PR DESCRIPTION
`Nette\Http\Session` calls the method `Nette\Http\IResponse::removeDuplicateCookies()`. This method however isn't defined on the interface but only in `Nette\Http\Response`. Therefore Session doesn't work with custom implementations of IResponse.

Is it ok to add the method to the interface or do you think it should be fixed differently?
