### PR TITLE
UrlScript: do not use magic method to access Url::$path

### DIFF
--- a/src/Http/UrlScript.php
+++ b/src/Http/UrlScript.php
@@ -63,7 +63,7 @@ class UrlScript extends Url
 	public function getBasePath()
 	{
 		$pos = strrpos($this->scriptPath, '/');
-		return $pos === FALSE ? '' : substr($this->path, 0, $pos + 1);
+		return $pos === FALSE ? '' : substr($this->getPath(), 0, $pos + 1);
 	}
 
 
@@ -73,7 +73,7 @@ class UrlScript extends Url
 	 */
 	public function getPathInfo()
 	{
-		return (string) substr($this->path, strlen($this->scriptPath));
+		return (string) substr($this->getPath(), strlen($this->scriptPath));
 	}
 
 }


### PR DESCRIPTION
While [benchmarking Nextras\StaticRouter](https://github.com/nextras/static-router/commit/8aa3142d031fca21dc7a3dfe07d3320a4d9a1a09) I noticed an easy-to-fix bottleneck in `getBasePath` method.
