### PR TITLE
Test and fix nette/http#15 - Session::configure overrides setHandler set...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,15 @@ matrix:
         - php: hhvm
 
 script:
-    - vendor/bin/tester tests -s
+    - vendor/bin/tester tests -s -c tests/php-unix.ini
     - php code-checker/src/code-checker.php -d src
 
 after_failure:
     # Print *.actual content
     - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
+
+services:
+    - redis-server
 
 before_script:
     # Install Nette Tester & Code Checker

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -63,6 +63,9 @@ class Session extends Nette\Object
 	/** @var IResponse */
 	private $response;
 
+	/** @var \SessionHandlerInterface */
+	private $handler;
+
 
 	public function __construct(IRequest $request, IResponse $response)
 	{
@@ -431,6 +434,10 @@ class Session extends Nette\Object
 				$this->sendCookie();
 			}
 		}
+
+		if (isset($this->handler)) {
+			session_set_save_handler($this->handler);
+		}
 	}
 
 
@@ -521,7 +528,7 @@ class Session extends Nette\Object
 		if (self::$started) {
 			throw new Nette\InvalidStateException('Unable to set handler when session has been started.');
 		}
-		session_set_save_handler($handler);
+		$this->handler = $handler;
 	}
 
 

--- a/tests/Http/Session.handler.nondefault.phpt
+++ b/tests/Http/Session.handler.nondefault.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: Nette\Http\Session storage.
+ * @phpversion 5.4
+ */
+
+use Nette\Http\Session,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class MySessionStorageExtension extends \SessionHandler
+{
+}
+
+
+$factory = new Nette\Http\RequestFactory;
+$session = new Nette\Http\Session($factory->createHttpRequest(), new Nette\Http\Response);
+
+$session->setOptions(array('save_handler' => 'redis', 'save_path' => 'tcp://127.0.0.1:6379')); //or anything different from default - memcached, memcache, mysql..
+Assert::same('files', ini_get('session.save_handler'));
+$session->setHandler(new MySessionStorageExtension);
+Assert::same('files', ini_get('session.save_handler'));
+$session->start(); //and configure();
+Assert::same('user', ini_get('session.save_handler'));

--- a/tests/Http/Session.handler.phpt
+++ b/tests/Http/Session.handler.phpt
@@ -56,8 +56,12 @@ class MySessionStorage extends Object implements SessionHandlerInterface
 $factory = new Nette\Http\RequestFactory;
 $session = new Nette\Http\Session($factory->createHttpRequest(), new Nette\Http\Response);
 
+//custom handler with default session.save_handler option ("files")
+Assert::same('files', ini_get('session.save_handler'));
 $session->setHandler(new MySessionStorage);
+Assert::same('files', ini_get('session.save_handler'));
 $session->start();
+Assert::same('user', ini_get('session.save_handler'));
 $_COOKIE['PHPSESSID'] = $session->getId();
 
 $namespace = $session->getSection('one');

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,0 +1,2 @@
+[PHP]
+extension=redis.so


### PR DESCRIPTION
...tings

  * this commit introduces unit test dependency on redis php extension. Don't know how to avoid it..

Issue: nette/http#15