### PR TITLE
Fix Http\Request::getFile() inconsistency

### DIFF
--- a/src/Http/IRequest.php
+++ b/src/Http/IRequest.php
@@ -53,7 +53,7 @@ interface IRequest
 
 	/**
 	 * Returns uploaded file.
-	 * @param  string key (or more keys)
+	 * @param  string key
 	 * @return FileUpload|NULL
 	 */
 	function getFile($key);

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -139,12 +139,17 @@ class Request extends Nette\Object implements IRequest
 
 	/**
 	 * Returns uploaded file.
-	 * @param  string key (or more keys)
+	 * @param  string key
 	 * @return FileUpload|NULL
 	 */
 	public function getFile($key)
 	{
-		return Nette\Utils\Arrays::get($this->files, func_get_args(), NULL);
+		if (func_num_args() > 1) {
+			trigger_error('Calling getFile() with multiple keys is deprecated.', E_USER_DEPRECATED);
+			return Nette\Utils\Arrays::get($this->files, func_get_args(), NULL);
+		}
+
+		return isset($this->files[$key]) ? $this->files[$key] : NULL;
 	}
 
 

--- a/tests/Http/Request.files.phpt
+++ b/tests/Http/Request.files.phpt
@@ -108,7 +108,5 @@ Assert::type( 'Nette\Http\FileUpload', $request->files['file3'][1] );
 Assert::false( isset($request->files['file0']) );
 Assert::true( isset($request->files['file1']) );
 
-Assert::null( $request->getFile('file1', 'a') );
-
 Assert::null( $request->getFile('empty1') );
 Assert::same( array(NULL), $request->getFile('empty2') );


### PR DESCRIPTION
`Http\Request::getFile()` is inconsistent with `getQuery` and `getPost`
- it uses `Nette\Utils\Arrays::get`; `getQuery` and `getPost` do not
- it does not support `$default` but always returns NULL (that kind of make sense) for undefined keys.
