### PR TITLE
Fix clowny session handler test

### DIFF
--- a/tests/Http/Session.handler.phpt
+++ b/tests/Http/Session.handler.phpt
@@ -20,15 +20,17 @@ class MySessionStorage extends Object implements SessionHandlerInterface
 	function open($savePath, $sessionName)
 	{
 		$this->path = $savePath;
+		return TRUE;
 	}
 
 	function close()
 	{
+		return TRUE;
 	}
 
 	function read($id)
 	{
-		return @file_get_contents("$this->path/sess_$id");
+		return (string) @file_get_contents("$this->path/sess_$id");
 	}
 
 	function write($id, $data)
@@ -38,7 +40,7 @@ class MySessionStorage extends Object implements SessionHandlerInterface
 
 	function destroy($id)
 	{
-		return @unlink("$this->path/sess_$id");
+		return !is_file("$this->path/sess_$id") || @unlink("$this->path/sess_$id");
 	}
 
 	function gc($maxlifetime)


### PR DESCRIPTION
This test is abusing a broken PHP behavior, where user session handlers are not properly checked for return values.
According to SessionHandlerInterface, these methods should return bool, except read, which must return string.
This bug is fixed in HHVM and PHP 7, where this test is constantly failing.
