### PR TITLE
RequestFactory: invalid byte sequences in $_SERVER['REQUEST_URI']

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -100,7 +100,10 @@ class RequestFactory extends Nette\Object
 
 		// normalized url
 		$url->canonicalize();
-		$url->setPath(Strings::fixEncoding($url->getPath()));
+
+		if (preg_match(self::NONCHARS, $url->getPath()) || preg_last_error()) {
+			throw new InvalidRequestException(); // TODO!
+		}
 
 		// detect script path
 		if (isset($_SERVER['SCRIPT_NAME'])) {


### PR DESCRIPTION
The goal is to not simply ignore invalid byte sequences in URL, but throw Exception or return NULL. Current Nette behavior is unwanted, e.g. these URLs should not be accepted at all:

```
http://doc.nette.org/en/2.2/%C0%C0%C0%C0%C0templating
https://www.rohlik.cz/stranka/%C0kontakt
```

---

How would you prefer to handle it? Exception or by returning NULL. Both break the RequestFactory API. I would prefer the exception, e. g. `Nette\Http\InvalidRequestException`. Do you like the name?

cc @fprochazka 
