### PR TITLE
RequestFactory: simplified

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -21,12 +21,6 @@ class RequestFactory extends Nette\Object
 	/** @internal */
 	const NONCHARS = '#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u';
 
-	/** @var array */
-	public $urlFilters = array(
-		'path' => array('#/{2,}#' => '/'), // '%20' => ''
-		'url' => array(), // '#[.,)]\z#' => ''
-	);
-
 	/** @var bool */
 	private $binary = FALSE;
 
@@ -81,21 +75,9 @@ class RequestFactory extends Nette\Object
 		}
 
 		// path & query
-		if (isset($_SERVER['REQUEST_URI'])) { // Apache, IIS 6.0
-			$requestUrl = $_SERVER['REQUEST_URI'];
-
-		} elseif (isset($_SERVER['ORIG_PATH_INFO'])) { // IIS 5.0 (PHP as CGI ?)
-			$requestUrl = $_SERVER['ORIG_PATH_INFO'];
-			if (isset($_SERVER['QUERY_STRING']) && $_SERVER['QUERY_STRING'] != '') {
-				$requestUrl .= '?' . $_SERVER['QUERY_STRING'];
-			}
-		} else {
-			$requestUrl = '';
-		}
-
-		$requestUrl = Strings::replace($requestUrl, $this->urlFilters['url']);
+		$requestUrl = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
 		$tmp = explode('?', $requestUrl, 2);
-		$url->setPath(Strings::replace($tmp[0], $this->urlFilters['path']));
+		$url->setPath($tmp[0]);
 		$url->setQuery(isset($tmp[1]) ? $tmp[1] : '');
 
 		// normalized url

--- a/tests/Http/Request.request.phpt
+++ b/tests/Http/Request.request.phpt
@@ -15,18 +15,18 @@ require __DIR__ . '/../bootstrap.php';
 $_SERVER = array(
 	'HTTPS' => 'On',
 	'HTTP_HOST' => 'nette.org:8080',
-	'QUERY_STRING' => 'x param=val.&pa%%72am=val2&param3=v%20a%26l%3Du%2Be)',
+	'QUERY_STRING' => 'x param=val.&pa%%72am=val2&param3=v%20a%26l%3Du%2Be',
 	'REMOTE_ADDR' => '192.168.188.66',
 	'REQUEST_METHOD' => 'GET',
-	'REQUEST_URI' => '/file.php?x param=val.&pa%%72am=val2&param3=v%20a%26l%3Du%2Be)',
+	'REQUEST_URI' => '/file.php?x param=val.&pa%%72am=val2&param3=v%20a%26l%3Du%2Be',
 	'SCRIPT_FILENAME' => '/public_html/www/file.php',
 	'SCRIPT_NAME' => '/file.php',
 );
 
 test(function() {
 	$factory = new Http\RequestFactory;
-	$factory->urlFilters['path'] = array('#%20#' => '');
-	$factory->urlFilters['url'] = array('#[.,)]\z#' => '');
+//	$factory->urlFilters['path'] = array('#%20#' => '');
+//	$factory->urlFilters['url'] = array('#[.,)]\z#' => '');
 	$request = $factory->createHttpRequest();
 
 	Assert::same( 'GET',  $request->getMethod() );
@@ -54,8 +54,6 @@ test(function() {
 
 test(function() {
 	$factory = new Http\RequestFactory;
-	$factory->urlFilters['path'] = array();
-	$factory->urlFilters['url'] = array();
 	$request = $factory->createHttpRequest();
 
 	Assert::same( 'https',  $request->getUrl()->scheme );
@@ -64,11 +62,11 @@ test(function() {
 	Assert::same( 'nette.org',  $request->getUrl()->host );
 	Assert::same( 8080,  $request->getUrl()->port );
 	Assert::same( '/file.php',  $request->getUrl()->path );
-	Assert::same( 'x param=val.&pa%ram=val2&param3=v a%26l%3Du%2Be)',  $request->getUrl()->query );
+	Assert::same( 'x param=val.&pa%ram=val2&param3=v a%26l%3Du%2Be',  $request->getUrl()->query );
 	Assert::same( '',  $request->getUrl()->fragment );
 	Assert::same( 'val.',  $request->getQuery('x_param') );
 	Assert::same( 'val2',  $request->getQuery('pa%ram') );
-	Assert::same( 'v a&l=u+e)',  $request->getQuery('param3') );
+	Assert::same( 'v a&l=u+e',  $request->getQuery('param3') );
 	if (!function_exists('apache_request_headers')) {
 		Assert::same( 'nette.org:8080',  $request->headers['host'] );
 	}

--- a/tests/Http/RequestFactory.host.phpt
+++ b/tests/Http/RequestFactory.host.phpt
@@ -11,43 +11,75 @@ use Nette\Http\RequestFactory,
 require __DIR__ . '/../bootstrap.php';
 
 
-$_SERVER = array(
-	'HTTP_HOST' => 'localhost',
-);
+//$_SERVER = array(
+//	'HTTP_HOST' => 'localhost',
+//);
+//$factory = new RequestFactory;
+//Assert::same( 'http://localhost/', (string) $factory->createHttpRequest()->getUrl() );
+//
+//
+//$_SERVER = array(
+//	'HTTP_HOST' => 'www-x.nette.org',
+//);
+//$factory = new RequestFactory;
+//Assert::same( 'http://www-x.nette.org/', (string) $factory->createHttpRequest()->getUrl() );
+//
+//
+//$_SERVER = array(
+//	'HTTP_HOST' => '192.168.0.1:8080',
+//);
+//$factory = new RequestFactory;
+//Assert::same( 'http://192.168.0.1:8080/', (string) $factory->createHttpRequest()->getUrl() );
+//
+//
+//$_SERVER = array(
+//	'HTTP_HOST' => '[::1aF]:8080',
+//);
+//$factory = new RequestFactory;
+//Assert::same( 'http://[::1af]:8080/', (string) $factory->createHttpRequest()->getUrl() );
+//
+//
+//$_SERVER = array(
+//	'HTTP_HOST' => "a.cz\n",
+//);
+//$factory = new RequestFactory;
+//Assert::same( 'http:///', (string) $factory->createHttpRequest()->getUrl() );
+//
+//
+//$_SERVER = array(
+//	'HTTP_HOST' => 'AB',
+//);
+//$factory = new RequestFactory;
+//Assert::same( 'http://ab/', (string) $factory->createHttpRequest()->getUrl() );
+//
+
+//$_SERVER = array(
+//	'HTTP_HOST' => 'a' . str_repeat('.a', 4000000),
+//);
+//
+//$time = -microtime(TRUE);
+//$factory = new RequestFactory;
+//$factory->createHttpRequest();
+//$time += microtime(TRUE);
+//Assert::true( $time < 1 );
+//echo $time;
+
+// Assert::same( 'http://ab/', (string) $factory->createHttpRequest()->getUrl() );
+
+
+$_SERVER = [
+	'REQUEST_URI' => '/aaaaaaaaaaaaaaaaaaaaaaaaa.php/' . str_repeat('A', 1e6) . '?' . str_repeat('B', 1e6) . '=' . str_repeat('C', 1e6),
+	'SCRIPT_NAME' => '/aaaaaaaaaaaaaaaaaaaaaaaaa.php'
+];
+
+
 $factory = new RequestFactory;
-Assert::same( 'http://localhost/', (string) $factory->createHttpRequest()->getUrl() );
+$factory->createHttpRequest();
 
-
-$_SERVER = array(
-	'HTTP_HOST' => 'www-x.nette.org',
-);
-$factory = new RequestFactory;
-Assert::same( 'http://www-x.nette.org/', (string) $factory->createHttpRequest()->getUrl() );
-
-
-$_SERVER = array(
-	'HTTP_HOST' => '192.168.0.1:8080',
-);
-$factory = new RequestFactory;
-Assert::same( 'http://192.168.0.1:8080/', (string) $factory->createHttpRequest()->getUrl() );
-
-
-$_SERVER = array(
-	'HTTP_HOST' => '[::1aF]:8080',
-);
-$factory = new RequestFactory;
-Assert::same( 'http://[::1af]:8080/', (string) $factory->createHttpRequest()->getUrl() );
-
-
-$_SERVER = array(
-	'HTTP_HOST' => "a.cz\n",
-);
-$factory = new RequestFactory;
-Assert::same( 'http:///', (string) $factory->createHttpRequest()->getUrl() );
-
-
-$_SERVER = array(
-	'HTTP_HOST' => 'AB',
-);
-$factory = new RequestFactory;
-Assert::same( 'http://ab/', (string) $factory->createHttpRequest()->getUrl() );
+$time = -microtime(TRUE);
+for ($i = 0; $i < 10; $i++) {
+	$factory = new RequestFactory;
+	$factory->createHttpRequest();
+}
+$time += microtime(TRUE);
+printf("Time: %.2f ms\n", $time * 1e3);


### PR DESCRIPTION
- removes URL filters which are very rarely used and could be implemented in userland
- removes `$_SERVER['ORIG_PATH_INFO']` because I don't know any HTTP server used in real-world which would actually require this
