### PR TITLE
Url: optimized unescape() performance

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -451,7 +451,7 @@ class Url extends Nette\Object
 
 
 	/**
-	 * Similar to rawurldecode, but preserve reserved chars encoded.
+	 * Similar to rawurldecode, but preserves reserved chars encoded.
 	 * @param  string to decode
 	 * @param  string reserved characters
 	 * @return string
@@ -461,14 +461,11 @@ class Url extends Nette\Object
 		// reserved (@see RFC 2396) = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" | "$" | ","
 		// within a path segment, the characters "/", ";", "=", "?" are reserved
 		// within a query component, the characters ";", "/", "?", ":", "@", "&", "=", "+", ",", "$" are reserved.
-		preg_match_all('#(?<=%)[a-f0-9][a-f0-9]#i', $s, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
-		foreach (array_reverse($matches) as $match) {
-			$ch = chr(hexdec($match[0][0]));
-			if (strpos($reserved, $ch) === FALSE) {
-				$s = substr_replace($s, $ch, $match[0][1] - 1, 3);
-			}
-		}
-		return $s;
+		return $reserved === '' ? rawurldecode($s) : preg_replace_callback(
+			'#(?:%(?!' . implode('|', str_split(bin2hex($reserved), 2)) . ')[0-9a-f]{2})++#i',
+			function($m) { return rawurldecode($m[0]); },
+			$s
+		);
 	}
 
 }

--- a/tests/Http/Url.unescape.phpt
+++ b/tests/Http/Url.unescape.phpt
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Test: Nette\Http\Url unescape.
+ */
+
+use Nette\Http\Url,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::same( 'foo + bar', Url::unescape('foo + bar') );
+Assert::same( 'foo + bar', Url::unescape('foo + bar', '') );
+Assert::same( 'foo', Url::unescape('%66%6F%6F', '') );
+Assert::same( 'f%6F%6F', Url::unescape('%66%6F%6F', 'o') );
+Assert::same( '%66oo', Url::unescape('%66%6F%6F', 'f') );
+Assert::same( '%66%6F%6F', Url::unescape('%66%6F%6F', 'fo') );
+Assert::same( '%66%6f%6f', Url::unescape('%66%6f%6f', 'fo') );
+Assert::same( "%00\x01%02", Url::unescape('%00%01%02', "\x00\x02") );


### PR DESCRIPTION
Currently unescape() can be used to perform DoS on Nette application if HTTP server does not restrict URL length.

Benchmark

``` php
const MAX_LENGTH = 256 * 1024;

$datasets = [
    'a' => ['%66%6F%6F', '', 'foo'],
    'b' => ['%66%6F%6F', 'o', 'f%6F%6F'],
    'c' => ['%66%6F%6F', 'f', '%66oo'],
    'd' => ['%66%6F%6F', 'fo', '%66%6F%6F'],
    'e' => ['%66%6f%6f', 'fo', '%66%6f%6f'],
    'no-escapes' => [str_repeat('a', MAX_LENGTH), '', str_repeat('a', MAX_LENGTH)],
    'escapes' => [str_repeat('%40', MAX_LENGTH / 3), '', str_repeat('@', MAX_LENGTH / 3)],
    'escapes2' => [str_repeat('%40', MAX_LENGTH / 6 - 3) . '%20' . str_repeat('%40', MAX_LENGTH / 6 - 3), ' ', str_repeat('@', MAX_LENGTH / 6 - 3) . '%20' . str_repeat('@', MAX_LENGTH / 6 - 3)],
    'escapes3' => [str_repeat('%40', MAX_LENGTH / 3), '@', str_repeat('%40', MAX_LENGTH / 3)],
    'escapes4' => [str_repeat('%40X', MAX_LENGTH / 4), '@', str_repeat('%40X', MAX_LENGTH / 4)],
    'escapes5' => [str_repeat('%40X%41Y', MAX_LENGTH / 8), '@', str_repeat("%40XAY", MAX_LENGTH / 8)],
];

$tests = [
    'old' => function ($testCount, $s, $reserved, $expected) {
        for ($i = 0; $i < $testCount; $i++) {
            $actual = $s;
            preg_match_all('#(?<=%)[a-f0-9][a-f0-9]#i', $s, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
            foreach (array_reverse($matches) as $match) {
                $ch = chr(hexdec($match[0][0]));
                if (strpos($reserved, $ch) === FALSE) {
                    $actual = substr_replace($actual, $ch, $match[0][1] - 1, 3);
                }
            }
        }
        Assert::same($expected, $actual);
    },
    'new' => function ($testCount, $s, $reserved, $expected) {
        for ($i = 0; $i < $testCount; $i++) {
            $actual = $s;
            preg_match_all('#%[a-f0-9][a-f0-9]#i', $s, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
            foreach (array_reverse($matches) as $match) {
                $ch = chr(hexdec(substr($match[0][0], 1)));
                if (strpos($reserved, $ch) === FALSE) {
                    $actual = substr_replace($actual, $ch, $match[0][1], 3);
                }
            }
        }
        Assert::same($expected, $actual);
    },
    'split' => function ($testCount, $s, $reserved, $expected) {
        for ($i = 0; $i < $testCount; $i++) {
            if ($reserved === '') {
                $actual = rawurldecode($s);
            } else {
                $pattern = '#((?:%(?:' . implode('|', str_split(bin2hex($reserved), 2)) . '))++)#i';
                $parts = preg_split($pattern, $s, -1, PREG_SPLIT_DELIM_CAPTURE);
                $max = count($parts);
                for ($j = 0; $j < $max; $j += 2) {
                    $parts[$j] = rawurldecode($parts[$j]);
                }
                $actual = implode('', $parts);

            }
        }
        Assert::same($expected, $actual);
    },
    'split-limited' => function ($testCount, $s, $reserved, $expected) {
        for ($i = 0; $i < $testCount; $i++) {
            if ($reserved === '') {
                $actual = rawurldecode($s);
            } else {
                $actual = $s;
                $pattern = '#((?:%(?:' . implode('|', str_split(bin2hex($reserved), 2)) . '))++)#i';
                $res = array();
                do {
                    $parts = preg_split($pattern, $actual, 1024, PREG_SPLIT_DELIM_CAPTURE);
                    $actual = isset($parts[2046]) ? $parts[2046] : '';
                    unset($parts[2046]);
                    $max = count($parts);
                    for ($j = 0; $j < $max; $j += 2) {
                        $parts[$j] = rawurldecode($parts[$j]);
                    }
                    $res[] = implode('', $parts);
                } while ($actual !== '');
                $actual = implode('', $res);
            }
        }
        Assert::same($expected, $actual);
    },
    'replace_callback' => function ($testCount, $s, $reserved, $expected) {
        for ($i = 0; $i < $testCount; $i++) {
            if ($reserved === '') {
                $actual = rawurldecode($s);
            } else {
                $pattern = '#(?:%(?!' . implode('|', str_split(bin2hex($reserved), 2)) . ')[0-9a-f]{2})++#i';
                $actual = preg_replace_callback(
                    $pattern,
                    function ($m) { return rawurldecode($m[0]); },
                    $s
                );
            }
        }
        Assert::same($expected, $actual);
    },
];

$testCount = 10;
$padLength = max(array_map('strlen', array_keys($datasets))) + 3;
set_time_limit(0);
ini_set('memory_limit', '512M');
foreach ($tests as $testName => $testCallback) {
    printf("Test %s:\n", $testName);
    foreach ($datasets as $datasetName => $dataset) {
        $time = -microtime(TRUE);
        $testCallback($testCount, ...$dataset);
        $time += microtime(TRUE);
        printf("  %s%5.0f ms\n", str_pad($datasetName, $padLength), $time * 1e3);
    }
    printf("\n");
}
```

Results:

```
Test old:
  a                0 ms
  b                0 ms
  c                0 ms
  d                0 ms
  e                0 ms
  no-escapes      84 ms
  escapes      11424 ms
  escapes2     12724 ms
  escapes3      2238 ms
  escapes4      1685 ms
  escapes5      8341 ms

Test new:
  a                0 ms
  b                0 ms
  c                0 ms
  d                0 ms
  e                0 ms
  no-escapes       1 ms
  escapes      14472 ms
  escapes2     15174 ms
  escapes3      2349 ms
  escapes4      1748 ms
  escapes5     13632 ms

Test split:
  a                0 ms
  b                0 ms
  c                1 ms
  d                0 ms
  e                0 ms
  no-escapes       4 ms
  escapes         71 ms
  escapes2       118 ms
  escapes3        29 ms
  escapes4       670 ms
  escapes5       375 ms

Test split-limited:
  a                0 ms
  b                0 ms
  c                0 ms
  d                0 ms
  e                0 ms
  no-escapes       3 ms
  escapes         71 ms
  escapes2       117 ms
  escapes3        30 ms
  escapes4       524 ms
  escapes5       314 ms

Test replace_callback:
  a                0 ms
  b                0 ms
  c                0 ms
  d                1 ms
  e                0 ms
  no-escapes       3 ms
  escapes         72 ms
  escapes2       107 ms
  escapes3        50 ms
  escapes4        36 ms
  escapes5       309 ms
```
