### PR TITLE
composer.json: fixed minimum requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	],
 	"require": {
 		"php": ">=5.3.1",
-		"nette/utils": "~2.2"
+		"nette/utils": "~2.2, >=2.2.2"
 	},
 	"require-dev": {
 		"nette/tester": "~1.0"


### PR DESCRIPTION
Session use `Nette\Utils\Callback::invokeSafe` which is available in nette/utils since 2.2.2. How did I figure it out?

``` sh
composer update --prefer-lowest && ./vendor/bin/tester -c ./tests/php-win.ini ./tests/
```

The question is – should we check this [automatically](https://github.com/symfony/symfony/commit/ef83a6cd6dae10e7af24329e547c1e3f117ede22)?

---

Note: this is available in Composer since [since Sunday](https://github.com/composer/composer/commit/d621c51b2ce1c2e1781ffb44b15c2a76a5ee0069).
