### PR TITLE
Url: changed to be immutable

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -62,11 +62,11 @@ class Request extends Nette\Object implements IRequest
 	public function __construct(UrlScript $url, $query = NULL, $post = NULL, $files = NULL, $cookies = NULL,
 		$headers = NULL, $method = NULL, $remoteAddress = NULL, $remoteHost = NULL, $rawBodyCallback = NULL)
 	{
-		$this->url = $url;
 		if ($query !== NULL) {
 			trigger_error('Nette\Http\Request::__construct(): parameter $query is deprecated.', E_USER_DEPRECATED);
-			$url->setQuery($query);
+			$url = $url->setQuery($query);
 		}
+		$this->url = $url;
 		$this->post = (array) $post;
 		$this->files = (array) $files;
 		$this->cookies = (array) $cookies;

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -64,19 +64,19 @@ class RequestFactory extends Nette\Object
 	{
 		// DETECTS URI, base path and script path of the request.
 		$url = new UrlScript;
-		$url->setScheme(!empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'off') ? 'https' : 'http');
-		$url->setUser(isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : '');
-		$url->setPassword(isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : '');
+		$url = $url->setScheme(!empty($_SERVER['HTTPS']) && strcasecmp($_SERVER['HTTPS'], 'off') ? 'https' : 'http');
+		$url = $url->setUser(isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : '');
+		$url = $url->setPassword(isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : '');
 
 		// host & port
 		if ((isset($_SERVER[$tmp = 'HTTP_HOST']) || isset($_SERVER[$tmp = 'SERVER_NAME']))
 			&& preg_match('#^([a-z0-9_.-]+|\[[a-f0-9:]+\])(:\d+)?\z#i', $_SERVER[$tmp], $pair)
 		) {
-			$url->setHost(strtolower($pair[1]));
+			$url = $url->setHost(strtolower($pair[1]));
 			if (isset($pair[2])) {
-				$url->setPort(substr($pair[2], 1));
+				$url = $url->setPort(substr($pair[2], 1));
 			} elseif (isset($_SERVER['SERVER_PORT'])) {
-				$url->setPort($_SERVER['SERVER_PORT']);
+				$url = $url->setPort($_SERVER['SERVER_PORT']);
 			}
 		}
 
@@ -86,8 +86,8 @@ class RequestFactory extends Nette\Object
 		$tmp = explode('?', $requestUrl, 2);
 		$path = Url::unescape($tmp[0], '%/?#');
 		$path = Strings::fixEncoding(Strings::replace($path, $this->urlFilters['path']));
-		$url->setPath($path);
-		$url->setQuery(isset($tmp[1]) ? $tmp[1] : '');
+		$url = $url->setPath($path);
+		$url = $url->setQuery(isset($tmp[1]) ? $tmp[1] : '');
 
 		// detect script path
 		$script = isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME'] : '';
@@ -96,7 +96,7 @@ class RequestFactory extends Nette\Object
 			for ($i = 0; $i < $max && $path[$i] === $script[$i]; $i++);
 			$path = $i ? substr($path, 0, strrpos($path, '/', $i - strlen($path) - 1) + 1) : '/';
 		}
-		$url->setScriptPath($path);
+		$url = $url->setScriptPath($path);
 
 		// GET, POST, COOKIE
 		$useFilter = (!in_array(ini_get('filter.default'), array('', 'unsafe_raw')) || ini_get('filter.default_flags'));
@@ -129,7 +129,7 @@ class RequestFactory extends Nette\Object
 			}
 			unset($list, $key, $val, $k, $v);
 		}
-		$url->setQuery($query);
+		$url = $url->setQuery($query);
 
 
 		// FILES and create FileUpload objects

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -101,8 +101,8 @@ class Url extends Nette\Object
 			$this->host = isset($p['host']) ? rawurldecode($p['host']) : '';
 			$this->user = isset($p['user']) ? rawurldecode($p['user']) : '';
 			$this->password = isset($p['pass']) ? rawurldecode($p['pass']) : '';
-			$this->setPath(isset($p['path']) ? $p['path'] : '');
-			$this->setQuery(isset($p['query']) ? $p['query'] : array());
+			self::setPathToUrl($this, isset($p['path']) ? $p['path'] : '');
+			self::setQueryToUrl($this, isset($p['query']) ? $p['query'] : array());
 			$this->fragment = isset($p['fragment']) ? rawurldecode($p['fragment']) : '';
 
 		} elseif ($url instanceof self) {
@@ -120,8 +120,9 @@ class Url extends Nette\Object
 	 */
 	public function setScheme($value)
 	{
-		$this->scheme = (string) $value;
-		return $this;
+		$clone = clone $this;
+		$clone->scheme = (string) $value;
+		return $clone;
 	}
 
 
@@ -142,8 +143,9 @@ class Url extends Nette\Object
 	 */
 	public function setUser($value)
 	{
-		$this->user = (string) $value;
-		return $this;
+		$clone = clone $this;
+		$clone->user = (string) $value;
+		return $clone;
 	}
 
 
@@ -164,8 +166,9 @@ class Url extends Nette\Object
 	 */
 	public function setPassword($value)
 	{
-		$this->password = (string) $value;
-		return $this;
+		$clone = clone $this;
+		$clone->password = (string) $value;
+		return $clone;
 	}
 
 
@@ -186,8 +189,9 @@ class Url extends Nette\Object
 	 */
 	public function setHost($value)
 	{
-		$this->host = (string) $value;
-		return $this;
+		$clone = clone $this;
+		$clone->host = (string) $value;
+		return $clone;
 	}
 
 
@@ -208,8 +212,9 @@ class Url extends Nette\Object
 	 */
 	public function setPort($value)
 	{
-		$this->port = (int) $value;
-		return $this;
+		$clone = clone $this;
+		$clone->port = (int) $value;
+		return $clone;
 	}
 
 
@@ -230,11 +235,23 @@ class Url extends Nette\Object
 	 */
 	public function setPath($value)
 	{
-		$this->path = (string) $value;
-		if (substr($this->path, 0, 1) !== '/' && in_array($this->scheme, array('http', 'https'), TRUE)) {
-			$this->path = '/' . $this->path;
+		return self::setPathToUrl(clone $this, $value);
+	}
+
+
+	/**
+	 * Sets the path part of URI.
+	 * @param Url
+	 * @param string
+	 * @return self
+	 */
+	private static function setPathToUrl(Url $url, $value)
+	{
+		$url->path = (string) $value;
+		if (substr($url->path, 0, 1) !== '/' && in_array($url->scheme, array('http', 'https'), TRUE)) {
+			$url->path = '/' . $url->path;
 		}
-		return $this;
+		return $url;
 	}
 
 
@@ -255,8 +272,20 @@ class Url extends Nette\Object
 	 */
 	public function setQuery($value)
 	{
-		$this->query = is_array($value) ? $value : self::parseQuery($value);
-		return $this;
+		return self::setQueryToUrl(clone $this, $value);
+	}
+
+
+	/**
+	 * Sets the query part of URI.
+	 * @param Url
+	 * @param string|array
+	 * @return self
+	 */
+	private function setQueryToUrl(Url $url, $value)
+	{
+		$url->query = is_array($value) ? $value : self::parseQuery($value);
+		return $url;
 	}
 
 
@@ -267,10 +296,11 @@ class Url extends Nette\Object
 	 */
 	public function appendQuery($value)
 	{
-		$this->query = is_array($value)
+		$clone = clone $this;
+		$clone->query = is_array($value)
 			? $value + $this->query
 			: self::parseQuery($this->getQuery() . '&' . $value);
-		return $this;
+		return $clone;
 	}
 
 
@@ -314,8 +344,9 @@ class Url extends Nette\Object
 	 */
 	public function setQueryParameter($name, $value)
 	{
-		$this->query[$name] = $value;
-		return $this;
+		$clone = clone $this;
+		$clone->query[$name] = $value;
+		return $clone;
 	}
 
 
@@ -326,8 +357,9 @@ class Url extends Nette\Object
 	 */
 	public function setFragment($value)
 	{
-		$this->fragment = (string) $value;
-		return $this;
+		$clone = clone $this;
+		$clone->fragment = (string) $value;
+		return $clone;
 	}
 
 
@@ -443,13 +475,14 @@ class Url extends Nette\Object
 	 */
 	public function canonicalize()
 	{
-		$this->path = preg_replace_callback(
+		$clone = clone $this;
+		$clone->path = preg_replace_callback(
 			'#[^!$&\'()*+,/:;=@%]+#',
 			function($m) { return rawurlencode($m[0]); },
-			self::unescape($this->path, '%/')
+			self::unescape($clone->path, '%/')
 		);
-		$this->host = strtolower($this->host);
-		return $this;
+		$clone->host = strtolower($clone->host);
+		return $clone;
 	}
 
 

--- a/src/Http/UrlScript.php
+++ b/src/Http/UrlScript.php
@@ -41,8 +41,9 @@ class UrlScript extends Url
 	 */
 	public function setScriptPath($value)
 	{
-		$this->scriptPath = (string) $value;
-		return $this;
+		$clone = clone $this;
+		$clone->scriptPath = (string) $value;
+		return $clone;
 	}
 
 

--- a/tests/Http/Url.canonicalize.phpt
+++ b/tests/Http/Url.canonicalize.phpt
@@ -12,19 +12,19 @@ require __DIR__ . '/../bootstrap.php';
 
 
 $url = new Url('http://hostname/path?arg=value&arg2=v%20a%26l%3Du%2Be');
-$url->canonicalize();
+$url = $url->canonicalize();
 Assert::same( 'http://hostname/path?arg=value&arg2=v%20a%26l%3Du%2Be', (string) $url );
 
 
 $url = new Url('http://username%3A:password%3A@hostN%61me:60/p%61th%2f%25()?arg=value&arg2=v%20a%26l%3Du%2Be#%61nchor');
-$url->canonicalize();
+$url = $url->canonicalize();
 Assert::same( 'http://hostname:60/path%2F%25()?arg=value&arg2=v%20a%26l%3Du%2Be#anchor', (string) $url );
 
 
 $url = new Url('http://host/%1f%20 %21!%22"%23%24$%25%26&%27\'%28(%29)%2a*%2b+%2c,%2d-%2e.%2f/%300%311%322%333%344%355%366%377%388%399%3a:%3b;%3c<%3d=%3e>%3f%40@'
 	. '%41A%42B%43C%44D%45E%46F%47G%48H%49I%4aJ%4bK%4cL%4dM%4eN%4fO%50P%51Q%52R%53S%54T%55U%56V%57W%58X%59Y%5aZ%5b[%5c\%5d]%5e^%5f_%60`'
 	. '%61a%62b%63c%64d%65e%66f%67g%68h%69i%6aj%6bk%6cl%6dm%6en%6fo%70p%71q%72r%73s%74t%75u%76v%77w%78x%79y%7az%7b{%7c|%7d}%7e~%7fá');
-$url->canonicalize();
+$url = $url->canonicalize();
 Assert::same( 'http://host/%1F%20%20!!%22%22%23$$%25&&\'\'(())**++,,--..%2F/00112233445566778899::;;%3C%3C==%3E%3E%3F@@'
 	. 'AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTUUVVWWXXYYZZ%5B%5B%5C%5C%5D%5D%5E%5E__%60%60'
 	. 'aabbccddeeffgghhiijjkkllmmnnooppqqrrssttuuvvwwxxyyzz%7B%7B%7C%7C%7D%7D~~%7F%C3%A1', (string) $url );

--- a/tests/Http/Url.httpScheme.phpt
+++ b/tests/Http/Url.httpScheme.phpt
@@ -29,20 +29,20 @@ Assert::same( 'http://hostname:60/p%61th/script.php?arg=value#anchor',  $url->ab
 Assert::same( 'http://hostname:60/p%61th/',  $url->baseUrl );
 Assert::same( 'script.php?arg=value#anchor',  $url->relativeUrl );
 
-$url->setPath('');
+$url = $url->setPath('');
 Assert::same( '/',  $url->getPath() );
 
-$url->setPath('/');
+$url = $url->setPath('/');
 Assert::same( '/',  $url->getPath() );
 
-$url->setPath('x');
+$url = $url->setPath('x');
 Assert::same( '/x',  $url->getPath() );
 
-$url->setPath('/x');
+$url = $url->setPath('/x');
 Assert::same( '/x',  $url->getPath() );
 
-$url->scheme = NULL;
+$url = $url->setScheme(NULL);
 Assert::same( '//username%3A:password%3A@hostname:60/x?arg=value#anchor',  $url->absoluteUrl );
 
-$url->setPath('');
+$url = $url->setPath('');
 Assert::same( '',  $url->getPath() );

--- a/tests/Http/Url.query.phpt
+++ b/tests/Http/Url.query.phpt
@@ -15,47 +15,46 @@ $url = new Url('http://hostname/path?arg=value');
 Assert::same( 'arg=value',  $url->query );
 Assert::same( array('arg' => 'value'),  $url->getQueryParameters() );
 
-$url->appendQuery(NULL);
+$url = $url->appendQuery(NULL);
 Assert::same( 'arg=value',  $url->query );
 Assert::same( array('arg' => 'value'),  $url->getQueryParameters() );
 
-$url->appendQuery(array(NULL));
+$url = $url->appendQuery(array(NULL));
 Assert::same( 'arg=value',  $url->query );
 Assert::same( array(NULL, 'arg' => 'value'),  $url->getQueryParameters() );
 
-$url->appendQuery('arg2=value2');
+$url = $url->appendQuery('arg2=value2');
 Assert::same( 'arg=value&arg2=value2',  $url->query );
 Assert::same( array('arg' => 'value', 'arg2' => 'value2'),  $url->getQueryParameters() );
 
-$url->appendQuery(array('arg3' => 'value3'));
-Assert::same( 'arg3=value3&arg=value&arg2=value2',  $url->query );
+$url = $url->appendQuery(array('arg3' => 'value3'));
+Assert::same( 'arg3=value3&arg=value&arg2=value2', $url->query );
 
-$url->appendQuery('arg4[]=1');
-$url->appendQuery('arg4[]=2');
-Assert::same( 'arg3=value3&arg=value&arg2=value2&arg4%5B0%5D=1&arg4%5B1%5D=2',  $url->query );
+$url = $url->appendQuery('arg4[]=1');
+$url = $url->appendQuery('arg4[]=2');
+Assert::same( 'arg3=value3&arg=value&arg2=value2&arg4%5B0%5D=1&arg4%5B1%5D=2', $url->query );
 
-$url->appendQuery('arg4[0]=3');
-Assert::same( 'arg3=value3&arg=value&arg2=value2&arg4%5B0%5D=3&arg4%5B1%5D=2',  $url->query );
+$url = $url->appendQuery('arg4[0]=3');
+Assert::same( 'arg3=value3&arg=value&arg2=value2&arg4%5B0%5D=3&arg4%5B1%5D=2', $url->query );
 
-$url->appendQuery(array('arg4' => 4));
+$url = $url->appendQuery(array('arg4' => 4));
 Assert::same( 'arg4=4&arg3=value3&arg=value&arg2=value2',  $url->query );
 
-
-$url->setQuery(array('arg3' => 'value3'));
+$url = $url->setQuery(array('arg3' => 'value3'));
 Assert::same( 'arg3=value3',  $url->query );
 Assert::same( array('arg3' => 'value3'),  $url->getQueryParameters() );
 
-$url->setQuery(array('arg' => 'value'));
+$url = $url->setQuery(array('arg' => 'value'));
 Assert::same( 'value', $url->getQueryParameter('arg') );
 Assert::same( NULL, $url->getQueryParameter('invalid') );
 Assert::same( 123, $url->getQueryParameter('invalid', 123) );
 
-$url->setQueryParameter('arg2', 'abc');
+$url = $url->setQueryParameter('arg2', 'abc');
 Assert::same( 'abc', $url->getQueryParameter('arg2') );
 Assert::same( array('arg' => 'value', 'arg2' => 'abc'),  $url->getQueryParameters() );
-$url->setQueryParameter('arg2', 'def');
+$url = $url->setQueryParameter('arg2', 'def');
 Assert::same( 'def', $url->getQueryParameter('arg2') );
 Assert::same( array('arg' => 'value', 'arg2' => 'def'),  $url->getQueryParameters() );
-$url->setQueryParameter('arg2', NULL);
+$url = $url->setQueryParameter('arg2', NULL);
 Assert::same( NULL, $url->getQueryParameter('arg2') );
 Assert::same( array('arg' => 'value', 'arg2' => NULL),  $url->getQueryParameters() );

--- a/tests/Http/UrlScript.modify.phpt
+++ b/tests/Http/UrlScript.modify.phpt
@@ -12,8 +12,8 @@ require __DIR__ . '/../bootstrap.php';
 
 
 $url = new UrlScript('http://nette.org:8080/file.php?q=search');
-$url->path = '/test/';
-$url->scriptPath = '/test/index.php';
+$url = $url->setPath('/test/');
+$url = $url->setScriptPath('/test/index.php');
 
 Assert::same( '/test/index.php',  $url->scriptPath );
 Assert::same( 'http://nette.org:8080/test/',  $url->baseUrl );


### PR DESCRIPTION
This is absolutely BC break. However there is not much other options. There could be another class `ImmutableScriptUrl` however I think it is not a good practice.

Immutability is always BC break in my opinion. The only solution is described above but it uses inheritance and immutability is only on the last class. It could be done as same as `DateTimeInterface` but you probably know how it ended in many applications :-) It could be also done as a composition but it has a disadvantage in the same way as `DateTimeInterface` - it cannot be used in all places where current `Url` is used.