### PR TITLE
UrlScript: added getAppPath()

### DIFF
--- a/src/Http/UrlScript.php
+++ b/src/Http/UrlScript.php
@@ -26,6 +26,7 @@ use Nette;
  * @author     David Grudl
  *
  * @property   string $scriptPath
+ * @property-read string $appPath
  * @property-read string $pathInfo
  */
 class UrlScript extends Url
@@ -53,6 +54,16 @@ class UrlScript extends Url
 	public function getScriptPath()
 	{
 		return $this->scriptPath;
+	}
+
+
+	/**
+	 * Returns application-specific path, e.g. what is behind script path.
+	 * @return string
+	 */
+	public function getAppPath()
+	{
+		return substr($this->getPath(), strrpos($this->scriptPath, '/') + 1);
 	}
 
 

--- a/tests/Http/UrlScript.modify.phpt
+++ b/tests/Http/UrlScript.modify.phpt
@@ -21,3 +21,21 @@ Assert::same( '/test/',  $url->basePath );
 Assert::same( '?q=search',  $url->relativeUrl );
 Assert::same( '',  $url->pathInfo );
 Assert::same( 'http://nette.org:8080/test/?q=search',  $url->absoluteUrl);
+
+
+$url = new UrlScript('http://nette.org:8080/www/about');
+$url->scriptPath = '/www/';
+
+Assert::same( '/www/about',  $url->path );
+Assert::same( '/www/',  $url->scriptPath );
+Assert::same( 'about',  $url->appPath );
+Assert::same( 'about',  $url->pathInfo );
+
+
+$url = new UrlScript('http://nette.org:8080/www/index.php');
+$url->scriptPath = '/www/index.php';
+
+Assert::same( '/www/index.php',  $url->path );
+Assert::same( '/www/index.php',  $url->scriptPath );
+Assert::same( 'index.php',  $url->appPath );
+Assert::same( '',  $url->pathInfo );


### PR DESCRIPTION
When implementing custom router you usually need this method. The algorithm was taken from https://github.com/nextras/static-router/blob/d97be13214443e03cc5efb849adc69d9ae0a2a5d/src/StaticRouter.php#L49 and it should be equivalent what Route [is doing](https://github.com/nette/application/blob/2d1e6b9880a3b375ce65df57ca3715850b6c0ecc/src/Application/Routers/Route.php#L162-L166) (just micro-optimized). Although I think I made some assumption which I'm not sure if they are generally true. However the idea is important, the algorithm could be polished.

Thoughts?
