### PR TITLE
Session: fetch session cookie from Http\IRequest

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -87,8 +87,10 @@ class Session extends Nette\Object
 
 		$this->configure($this->options);
 
-		$id = & $_COOKIE[session_name()];
-		if (!is_string($id) || !preg_match('#^[0-9a-zA-Z,-]{22,128}\z#i', $id)) {
+		$id = $this->request->getCookie(session_name());
+		if (is_string($id) && preg_match('#^[0-9a-zA-Z,-]{22,128}\z#i', $id)) {
+			session_id($id);
+		} else {
 			unset($_COOKIE[session_name()]);
 		}
 

--- a/tests/Http/Session.id.phpt
+++ b/tests/Http/Session.id.phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: Nette\Http\Session accepts cookie from Http\IRequest
+ */
+
+use Nette\Http,
+	Nette\Http\Session,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$_COOKIE['PHPSESSID'] = $leet = md5(1337);
+
+// create fake session
+$cookies = array('PHPSESSID' => $sessionId = md5(1), 'nette-browser' => $B = substr(md5(2), 0, 10));
+file_put_contents(TEMP_DIR . '/sess_' . $sessionId, sprintf('__NF|a:3:{s:4:"Time";i:%s;s:1:"B";s:10:"%s";s:4:"DATA";a:1:{s:4:"temp";a:1:{s:5:"value";s:3:"yes";}}}', time() - 1000, $B));
+
+$session = new Session(new Http\Request(new Http\UrlScript('http://nette.org'), NULL, array(), array(), $cookies), new Http\Response());
+
+$session->start();
+Assert::same($sessionId, $session->getId());
+Assert::same(array('PHPSESSID' => $leet), $_COOKIE);
+
+Assert::same('yes', $session->getSection('temp')->value);
+$session->close();
+
+// session was not regenerated
+Assert::true(file_exists(TEMP_DIR . '/sess_' . $sessionId));
+Assert::count(1, glob(TEMP_DIR . '/sess_*'));

--- a/tests/Http/Session.regenerate-empty-session.phpt
+++ b/tests/Http/Session.regenerate-empty-session.phpt
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Test: Nette\Http\Session::regenerateId() regenerate empty session
+ */
+
+use Nette\Http,
+	Nette\Http\Session,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// create fake session
+$cookies = array('PHPSESSID' => $sessionId = md5(3), 'nette-browser' => $B = substr(md5(4), 0, 10));
+file_put_contents(TEMP_DIR . '/sess_' . $sessionId, '__NF|a:1:{s:4:"DATA";a:1:{s:4:"temp";a:1:{s:5:"value";s:3:"yes";}}}');
+
+$session = new Session(new Http\Request(new Http\UrlScript('http://nette.org'), NULL, array(), array(), $cookies), new Http\Response());
+$session->start();
+Assert::same('yes', $session->getSection('temp')->value);
+
+$newSessionId = $session->getId();
+$session->close();
+
+// session was regenerated
+Assert::false(file_exists(TEMP_DIR . '/sess_' . $sessionId));
+Assert::true(file_exists(TEMP_DIR . '/sess_' . $newSessionId));
+Assert::count(1, glob(TEMP_DIR . '/sess_*'));


### PR DESCRIPTION
The `nette-browser` is also fetched from `Http\IRequest`, so the `session_name()` should probably be too.

For example I might be writing my own little http server using [react.php](https://github.com/reactphp/http) that accepts requests and processes them through sockets and is started from CLI. This would mean that I have to initialize the `$_COOKIES` variable instead of passing it in a nice OO interface through manually created `Http\Request`.

The fetching of the cookie alone would help a lot. The setting of the cookie to the global variable is a paranoid safety-net, for cases where something depends on the variable existing other than `Nette\Http\Session`. If you have a problem with modifying the global variable, I can remove it. But I'd rather keep it there.