### PR TITLE
Session: fix handling exceptions thrown from SessionHandlerInterface

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -92,15 +92,18 @@ class Session extends Nette\Object
 			unset($_COOKIE[session_name()]);
 		}
 
-		// session_start returns FALSE on failure only sometimes
-		Nette\Utils\Callback::invokeSafe('session_start', array(), function($message) use (& $error) {
-			$error = $message;
-		});
+		try {
+			// session_start returns FALSE on failure only sometimes
+			Nette\Utils\Callback::invokeSafe('session_start', array(), function ($message) use (& $e) {
+				$e = new Nette\InvalidStateException($message);
+			});
+		} catch (\Exception $e) {
+		}
 
 		Helpers::removeDuplicateCookies();
-		if ($error) {
+		if ($e) {
 			@session_write_close(); // this is needed
-			throw new Nette\InvalidStateException($error);
+			throw $e;
 		}
 
 		self::$started = TRUE;

--- a/tests/Http/Session.handler-exceptions.phpt
+++ b/tests/Http/Session.handler-exceptions.phpt
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Test: Nette\Http\Session handle storage exceptions.
+ * @phpversion 5.4
+ */
+
+use Nette\Http,
+	Nette\Http\Session,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class ThrowsOnReadHandler extends \SessionHandler
+{
+
+	public function open($save_path, $session_id)
+	{
+		return TRUE; // never throw an exception from here, the universe might implode
+	}
+
+
+
+	public function read($session_id)
+	{
+		throw new RuntimeException("Session can't be started for whatever reason!");
+	}
+
+}
+
+
+$session = new Nette\Http\Session(new Http\Request(new Http\UrlScript('http://nette.org')), new Http\Response);
+$session->setHandler(new ThrowsOnReadHandler);
+
+Assert::exception(function () use ($session) {
+	$session->start();
+}, 'RuntimeException', 'Session can\'t be started for whatever reason!');
+
+Assert::exception(function () use ($session) {
+	$session->start();
+}, 'RuntimeException', 'Session can\'t be started for whatever reason!');
+
+$session->setHandler(new \SessionHandler());
+$session->start();


### PR DESCRIPTION
I need to throw exception the SessionHandler.

Currently, when you throw an exception from there, the php thinks the session is started (it doesn't care about the exception) and Nette think it's not started, because the `self::$started = TRUE;` wasn't executed.

This creates a buggy state, where you cannot call `$session->start()` again, because it throws `Nette\InvalidStateException("session_start(): session is already started")`

Failing test is provided.