### PR TITLE
RequestFactory: reverted that script path detection is case-sensitive

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -90,10 +90,11 @@ class RequestFactory extends Nette\Object
 		$url->setQuery(isset($tmp[1]) ? $tmp[1] : '');
 
 		// detect script path
-		$script = isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME'] : '';
-		if ($path !== $script) {
-			$max = min(strlen($path), strlen($script));
-			for ($i = 0; $i < $max && $path[$i] === $script[$i]; $i++);
+		$lpath = strtolower($path);
+		$script = isset($_SERVER['SCRIPT_NAME']) ? strtolower($_SERVER['SCRIPT_NAME']) : '';
+		if ($lpath !== $script) {
+			$max = min(strlen($lpath), strlen($script));
+			for ($i = 0; $i < $max && $lpath[$i] === $script[$i]; $i++);
 			$path = $i ? substr($path, 0, strrpos($path, '/', $i - strlen($path) - 1) + 1) : '/';
 		}
 		$url->setScriptPath($path);

--- a/tests/Http/RequestFactory.scriptPath.phpt
+++ b/tests/Http/RequestFactory.scriptPath.phpt
@@ -111,7 +111,7 @@ test(function() use ($factory) {
 		'SCRIPT_NAME' => '/blog/www/index.php',
 	);
 
-	Assert::same( '/blog/', $factory->createHttpRequest()->getUrl()->getScriptPath() );
+	Assert::same( '/blog/WWW/', $factory->createHttpRequest()->getUrl()->getScriptPath() );
 });
 
 


### PR DESCRIPTION
This is very annoying on Windows. Either it must give a meaningful exception message, or be case insensitive.

This reverts commit 06cc6f48b73a2ab2a3c902e4d869eeef4aa810ce