### PR TITLE
Request: added ::getReferrer (RFC 1945 misspelling)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ echo $httpRequest->getRemoteHost();    // and its DNS translation
 What URL the user came from? Returned as [Nette\Http\Url |urls] object.
 
 ```php
-echo $httpRequest->getReferer()->host;
+echo $httpRequest->getReferrer()->host;
 ```
 
 Request parameters:

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -22,7 +22,7 @@ use Nette;
  * @property-read array $cookies
  * @property-read string $method
  * @property-read array $headers
- * @property-read Url|NULL $referer
+ * @property-read Url|NULL $referrer
  * @property-read bool $secured
  * @property-read bool $ajax
  * @property-read string|NULL $remoteAddress
@@ -238,9 +238,20 @@ class Request extends Nette\Object implements IRequest
 	 * Returns referrer.
 	 * @return Url|NULL
 	 */
-	public function getReferer()
+	public function getReferrer()
 	{
 		return isset($this->headers['referer']) ? new Url($this->headers['referer']) : NULL;
+	}
+
+
+	/**
+	 * Returns referrer.
+	 * @return Url|NULL
+	 * @deprecated Use ::getReferrer instead.
+	 */
+	public function getReferer()
+	{
+		return $this->getReferrer();
 	}
 
 

--- a/tests/Http/Request.headers.phpt
+++ b/tests/Http/Request.headers.phpt
@@ -37,3 +37,16 @@ test(function() {
 	Assert::same('2', $request->getHeader('Two'));
 	Assert::same('X', $request->getHeader('X-Header'));
 });
+
+test(function() {
+	$emptyRequest = new Http\Request(new Http\UrlScript);
+	Assert::null($emptyRequest->getHeader('referer'));
+	Assert::null($emptyRequest->getReferrer());
+
+	$referrerRequest = new Http\Request(new Http\UrlScript, NULL, NULL, NULL, NULL, array(
+		'referer' => 'http://nette.org/',
+	));
+	Assert::same('http://nette.org/', $referrerRequest->getHeader('referer'));
+	Assert::type('Nette\Http\Url', $referrerRequest->getReferrer());
+	Assert::same('http://nette.org/', $referrerRequest->getReferrer()->getAbsoluteUrl());
+});


### PR DESCRIPTION
I see, Nette\Http wraps HTTP headers and for some of them offers direct accessor methods.

But header *Referer* is misspelled (but accepted in RFC 1945) and I think we should hide this typo in object-oriented wrapper.
Instead of `Request::getReferer` we should offer correct word `Request::getReferrer`.

What do you think about this?

PHP itself uses HTTP_REFERER as server variable, header is really *referer* and nothing else.
I know it. But shouldn't we use correct accessor name (without misspelling)?