### PR TITLE
Url::getQuery: PHP version condition fixed

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -282,7 +282,7 @@ class Url extends Nette\Object
 	 */
 	public function getQuery()
 	{
-		if (PHP_VERSION < 50400) {
+		if (PHP_VERSION_ID < 50400) {
 			return str_replace('+', '%20', http_build_query($this->query, '', '&'));
 		}
 		return http_build_query($this->query, '', '&', PHP_QUERY_RFC3986);


### PR DESCRIPTION
It was a typo in condition for PHP version checking.
"Else" condition was never been called.

Result of the method should be unchanged after the PR.