### PR TITLE
add generic get method

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -14,6 +14,7 @@ use Nette;
  * HttpRequest provides access scheme for request sent via HTTP.
  *
  * @author     David Grudl
+ * @author     Nicola Pietroluongo <nik.longstone@gmail.com>
  *
  * @property-read UrlScript $url
  * @property-read array $query
@@ -176,8 +177,34 @@ class Request extends Nette\Object implements IRequest
 		return $this->cookies;
 	}
 
+    /**
+     * Provides a flexible generic get method.
+     * It follows an order of precedence: GET, POST, FILE.
+     *
+     * @param $key
+     * @param $default
+     *
+     * @return mixed
+     */
+    public function get($key, $default = NULL)
+    {
+        if (null !== $result = $this->getQuery($key)) {
+            return $result;
+        }
 
-	/********************* method & headers ****************d*g**/
+        if (null !== $result = $this->getPost($key)) {
+            return $result;
+        }
+
+        if (null !== $result = $this->getFile($key)) {
+            return $result;
+        }
+
+        return $default;
+    }
+
+
+    /********************* method & headers ****************d*g**/
 
 
 	/**

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -177,34 +177,32 @@ class Request extends Nette\Object implements IRequest
 		return $this->cookies;
 	}
 
-    /**
-     * Provides a flexible generic get method.
-     * It follows an order of precedence: GET, POST, FILE.
-     *
-     * @param $key
-     * @param $default
-     *
-     * @return mixed
-     */
-    public function get($key, $default = NULL)
-    {
-        if (null !== $result = $this->getQuery($key)) {
-            return $result;
-        }
+	/**
+	 * Provides a flexible generic get method.
+	* It follows an order of precedence: GET, POST, FILE.
+	* @param $key
+	* @param $default
+	*
+	* @return mixed
+	*/
+	public function get($key, $default = NULL)
+	{
+		if (null !== $result = $this->getQuery($key)) {
+		return $result;
+		}
 
-        if (null !== $result = $this->getPost($key)) {
-            return $result;
-        }
+		if (null !== $result = $this->getPost($key)) {
+		return $result;
+		}
 
-        if (null !== $result = $this->getFile($key)) {
-            return $result;
-        }
+		if (null !== $result = $this->getFile($key)) {
+		return $result;
+		}
 
-        return $default;
-    }
+		return $default;
+	}
 
-
-    /********************* method & headers ****************d*g**/
+/********************* method & headers ****************d*g**/
 
 
 	/**

--- a/tests/Http/Request.get.phpt
+++ b/tests/Http/Request.get.phpt
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Test: Nette\Http\Request get.
+ */
+
+use Nette\Http\RequestFactory,
+    Nette\Http\FileUpload,
+	Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// Test for GET
+$_SERVER = array(
+	'REQUEST_METHOD' => 'GET',
+	'REQUEST_URI' => '/file.php?x param=val.&pa%%72am=val2&quotes\\"=\\"&param3=v%20a%26l%3Du%2Be)',
+);
+test(function() {
+    $factory = new RequestFactory;
+    $request = $factory->createHttpRequest();
+
+	Assert::same('GET', $request->getMethod());
+	Assert::same('val.', $request->get('x_param'));
+});
+
+// Test for POST
+$_SERVER = array(
+	'REQUEST_METHOD' => 'POST'
+);
+$_POST = array(
+    'x_param' => 'val.'
+);
+test(function() {
+    $factory = new RequestFactory;
+    $request = $factory->createHttpRequest();
+
+	Assert::same('POST', $request->getMethod());
+	Assert::same('val.', $request->get('x_param'));
+});
+
+// Test for FILES
+test(function() {
+    $_FILES = array(
+        'file' => array(
+            'name' => 'readme.txt',
+            'type' => 'text/plain',
+            'tmp_name' => __DIR__ . '/files/file.txt',
+            'error' => 0,
+            'size' => 209,
+        )
+    );
+    $upload = new FileUpload($_FILES['file']);
+    $factory = new RequestFactory;
+    $request = $factory->createHttpRequest();
+
+	Assert::equal($upload, $request->getFile('file'));
+});

--- a/tests/Http/Request.get.phpt
+++ b/tests/Http/Request.get.phpt
@@ -5,7 +5,7 @@
  */
 
 use Nette\Http\RequestFactory,
-    Nette\Http\FileUpload,
+	Nette\Http\FileUpload,
 	Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
@@ -17,8 +17,8 @@ $_SERVER = array(
 	'REQUEST_URI' => '/file.php?x param=val.&pa%%72am=val2&quotes\\"=\\"&param3=v%20a%26l%3Du%2Be)',
 );
 test(function() {
-    $factory = new RequestFactory;
-    $request = $factory->createHttpRequest();
+	$factory = new RequestFactory;
+	$request = $factory->createHttpRequest();
 
 	Assert::same('GET', $request->getMethod());
 	Assert::same('val.', $request->get('x_param'));
@@ -29,11 +29,11 @@ $_SERVER = array(
 	'REQUEST_METHOD' => 'POST'
 );
 $_POST = array(
-    'x_param' => 'val.'
+	'x_param' => 'val.'
 );
 test(function() {
-    $factory = new RequestFactory;
-    $request = $factory->createHttpRequest();
+	$factory = new RequestFactory;
+	$request = $factory->createHttpRequest();
 
 	Assert::same('POST', $request->getMethod());
 	Assert::same('val.', $request->get('x_param'));
@@ -41,18 +41,18 @@ test(function() {
 
 // Test for FILES
 test(function() {
-    $_FILES = array(
-        'file' => array(
-            'name' => 'readme.txt',
-            'type' => 'text/plain',
-            'tmp_name' => __DIR__ . '/files/file.txt',
-            'error' => 0,
-            'size' => 209,
-        )
-    );
-    $upload = new FileUpload($_FILES['file']);
-    $factory = new RequestFactory;
-    $request = $factory->createHttpRequest();
+	$_FILES = array(
+		'file' => array(
+			'name' => 'readme.txt',
+			'type' => 'text/plain',
+			'tmp_name' => __DIR__ . '/files/file.txt',
+			'error' => 0,
+			'size' => 209,
+		)
+	);
+	$upload = new FileUpload($_FILES['file']);
+	$factory = new RequestFactory;
+	$request = $factory->createHttpRequest();
 
 	Assert::equal($upload, $request->getFile('file'));
 });


### PR DESCRIPTION
add a generic get  method to the Request class.
it is an alternative use of getQuery, getPost and getFile method.

- feature
- issues - none
- documentation - needed: nette/web-content#285
- BC break - no