### PR TITLE
Helpers ipMatch: arguments do not match when one is empty

### DIFF
--- a/src/Http/Helpers.php
+++ b/src/Http/Helpers.php
@@ -36,6 +36,10 @@ class Helpers
 	 */
 	public static function ipMatch($ip, $mask)
 	{
+		if (empty($ip) || empty($mask)) {
+			throw new Nette\InvalidArgumentException("The arguments cannot be empty.");
+		}
+
 		list($mask, $size) = explode('/', $mask . '/');
 		$tmp = function ($n) { return sprintf('%032b', $n); };
 		$ip = implode('', array_map($tmp, unpack('N*', inet_pton($ip))));

--- a/tests/Http/Helpers.phpt
+++ b/tests/Http/Helpers.phpt
@@ -45,3 +45,33 @@ test(function () {
 	Assert::same('Tue, 15 Nov 1994 08:12:31 GMT', Helpers::formatDate(new DateTime('1994-11-15T06:12:31-0200')));
 	Assert::same('Tue, 15 Nov 1994 08:12:31 GMT', Helpers::formatDate(784887151));
 });
+
+
+
+test(function () {
+	Assert::exception(function () {
+		Helpers::ipMatch(NULL, '192.168.68.233');
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+	Assert::exception(function () {
+		Helpers::ipMatch('', '192.168.68.233');
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+	Assert::exception(function () {
+		Helpers::ipMatch(0, '192.168.68.233');
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+	Assert::exception(function () {
+		Helpers::ipMatch(FALSE, '192.168.68.233');
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+
+	Assert::exception(function () {
+		Helpers::ipMatch('192.168.68.233', NULL);
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+	Assert::exception(function () {
+		Helpers::ipMatch('192.168.68.233', '');
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+	Assert::exception(function () {
+		Helpers::ipMatch('192.168.68.233', 0);
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+	Assert::exception(function () {
+		Helpers::ipMatch('192.168.68.233', FALSE);
+	}, 'Nette\InvalidArgumentException', 'The arguments cannot be empty.');
+});


### PR DESCRIPTION
When there is no ip-address in the `$_SERVER`, the application hangs, because it tries to resolve empty string.

![snimek obrazovky porizeny 2015-07-05 08 59 03](https://cloud.githubusercontent.com/assets/158625/8510651/1ce47e8c-22f4-11e5-8f4e-e820b9db8fe5.png)
