### PR TITLE
Request: added withUrl()

### DIFF
--- a/src/Http/IRequest.php
+++ b/src/Http/IRequest.php
@@ -138,4 +138,11 @@ interface IRequest
 	 */
 	function getRawBody();
 
+
+	/**
+	 * Returns new IRequest instance with modified URL.
+	 * @return IRequest
+	 */
+	// public function withUrl(UrlScript $url);
+
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -294,6 +294,19 @@ class Request extends Nette\Object implements IRequest
 
 
 	/**
+	 * Returns new IRequest instance with modified URL.
+	 * @return IRequest
+	 */
+	public function withUrl(UrlScript $url)
+	{
+		return new static(
+			$url, NULL, $this->post, $this->files, $this->cookies, $this->headers, $this->method,
+			$this->remoteAddress, $this->remoteHost, $this->rawBodyCallback
+		);
+	}
+
+
+	/**
 	 * Parse Accept-Language header and returns preferred language.
 	 * @param  string[] supported languages
 	 * @return string|NULL


### PR DESCRIPTION
It's often useful (e.g. in tests) to modify URL inside httpRequest. Doing this is really annoying because Request has lot of constructor parameters. The naming (`with*`) is based on PSR-7.

What do you think about this idea? Tests are currently missing.
