### PR TITLE
PHP 5.6: Remove raw body callback, php://input is seekable now

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -72,6 +72,9 @@ class Request extends Nette\Object implements IRequest
 		$this->method = $method ?: 'GET';
 		$this->remoteAddress = $remoteAddress;
 		$this->remoteHost = $remoteHost;
+		if ($rawBodyCallback !== NULL) {
+			trigger_error('Nette\Http\Request::__construct(): parameter $rawBodyCallback is deprecated.', E_USER_DEPRECATED);
+		}
 		$this->rawBodyCallback = $rawBodyCallback;
 	}
 
@@ -287,7 +290,8 @@ class Request extends Nette\Object implements IRequest
 	 */
 	public function getRawBody()
 	{
-		return $this->rawBodyCallback ? call_user_func($this->rawBodyCallback) : NULL;
+		$body = $this->rawBodyCallback ? call_user_func($this->rawBodyCallback) : file_get_contents('php://input');
+		return $body !== '' ? $body : NULL;
 	}
 
 

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -210,21 +210,7 @@ class RequestFactory extends Nette\Object
 			$method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
 		}
 
-		// raw body
-		$rawBodyCallback = function () {
-			static $rawBody;
-
-			if (PHP_VERSION_ID >= 50600) {
-				return file_get_contents('php://input');
-
-			} elseif ($rawBody === NULL) { // can be read only once in PHP < 5.6
-				$rawBody = (string) file_get_contents('php://input');
-			}
-
-			return $rawBody;
-		};
-
-		return new Request($url, NULL, $post, $files, $cookies, $headers, $method, $remoteAddr, $remoteHost, $rawBodyCallback);
+		return new Request($url, NULL, $post, $files, $cookies, $headers, $method, $remoteAddr, $remoteHost);
 	}
 
 }

--- a/tests/Http/Request.getRawBody.phpt
+++ b/tests/Http/Request.getRawBody.phpt
@@ -11,8 +11,9 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
+// compatibility
 test(function () {
-	$request = new Http\Request(new Http\UrlScript, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, function () {
+	@$request = new Http\Request(new Http\UrlScript, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, function () {
 		return 'raw body';
 	});
 


### PR DESCRIPTION
BC break (deprecation of `$rawBodyCallback` in constructor)
I'd also remove NULL on empty data and return empty string, but I'm not sure about implications in user-land...

Depends on #70 (composer.json & Travis).