### PR TITLE
IRequest: added PATCH method constant

### DIFF
--- a/src/Http/IRequest.php
+++ b/src/Http/IRequest.php
@@ -19,7 +19,8 @@ interface IRequest
 		POST = 'POST',
 		HEAD = 'HEAD',
 		PUT = 'PUT',
-		DELETE = 'DELETE';
+		DELETE = 'DELETE',
+		PATCH = 'PATCH';
 
 	/**
 	 * Returns URL object.


### PR DESCRIPTION
- **feature:** Added PATCH to method constants in `Nette\Http\IRequest` interface. It could be handy when designing REST APIs with Nette framework.
- **issues:** none
- **documentation:** not needed
- **BC break:** no