### PR TITLE
Do not suppress 'permission denied' warnings in FileUpload::move()

### DIFF
--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -149,7 +149,7 @@ class FileUpload extends Nette\Object
 		@mkdir($dir, 0777, TRUE); // @ - dir may already exist
 		@unlink($dest); // @ - file may not exists
 		if (!is_dir($dir)) {
-			throw new \Nette\InvalidStateException("Permission denied: directory '$dir' cannot be created.");
+			throw new \Nette\InvalidStateException("Directory '$dir' cannot be created.");
 		}
 		if (file_exists($dest) && !is_writable($dest)) {
 			throw new \Nette\InvalidStateException("Permission denied: file '$dest' cannot be removed.");

--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -145,8 +145,13 @@ class FileUpload extends Nette\Object
 	 */
 	public function move($dest)
 	{
-		@mkdir(dirname($dest), 0777, TRUE); // @ - dir may already exist
-		@unlink($dest); // @ - file may not exists
+		$dir = dirname($dest);
+		if (!is_dir($dir)) {
+			mkdir(dirname($dest), 0777, TRUE);
+		}
+		if (file_exists($dest)) {
+			unlink($dest);
+		}
 		if (!call_user_func(is_uploaded_file($this->tmpName) ? 'move_uploaded_file' : 'rename', $this->tmpName, $dest)) {
 			throw new Nette\InvalidStateException("Unable to move uploaded file '$this->tmpName' to '$dest'.");
 		}

--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -146,11 +146,13 @@ class FileUpload extends Nette\Object
 	public function move($dest)
 	{
 		$dir = dirname($dest);
+		@mkdir($dir, 0777, TRUE); // @ - dir may already exist
+		@unlink($dest); // @ - file may not exists
 		if (!is_dir($dir)) {
-			mkdir(dirname($dest), 0777, TRUE);
+			throw new \Nette\InvalidStateException("Permission denied: directory '$dir' cannot be created.");
 		}
-		if (file_exists($dest)) {
-			unlink($dest);
+		if (file_exists($dest) && !is_writable($dest)) {
+			throw new \Nette\InvalidStateException("Permission denied: file '$dest' cannot be removed.");
 		}
 		if (!call_user_func(is_uploaded_file($this->tmpName) ? 'move_uploaded_file' : 'rename', $this->tmpName, $dest)) {
 			throw new Nette\InvalidStateException("Unable to move uploaded file '$this->tmpName' to '$dest'.");


### PR DESCRIPTION
This commit adds more comprehensible error reporting to the `move()` method in the following scenarios:

* Say the program has insufficient permissions to create the directory `dirname($dest)`. With this commit the `move()` method correctly raises `mkdir(): Permission denied` warning instead of warning raised by `move_uploaded_file`: `failed to open stream: No such file or directory` with previous code.
* Or the already existing file at `$dest` may not be deleted with the current permissions. With this commit a correct `Permission denied` warning is again raised by `unlink` instead of warning raised by `move_uploaded_file` with previous code.