### PR TITLE
Use better detection for started session

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -404,7 +404,7 @@ class Session extends Nette\Object
 				$cookie[substr($key, 7)] = $value;
 
 			} else {
-				if (defined('SID')) {
+				if (session_status() === PHP_SESSION_ACTIVE) {
 					throw new Nette\InvalidStateException("Unable to set 'session.$key' to value '$value' when session has been started" . ($this->started ? '.' : ' by session.auto_start or session_start().'));
 				}
 				if (isset($special[$key])) {


### PR DESCRIPTION
Constant `SID` doesn't detect active session properly and might return `TRUE` for inactive session.
Since PHP 5.4 there is better way to detect: [`session_status()`](http://php.net/manual/es/function.session-status.php)

```php
session_start();
var_dump(defined('SID')); // TRUE
var_dump(session_status() === PHP_SESSION_ACTIVE); // TRUE

session_destroy();
var_dump(defined('SID')); // TRUE
var_dump(session_status() === PHP_SESSION_ACTIVE); // FALSE
```