### PR TITLE
better URI syntax complience

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -376,7 +376,7 @@ class Url implements \JsonSerializable
 	 */
 	public function getHostUrl()
 	{
-		return ($this->scheme ? $this->scheme . ':' : '') . '//' . $this->getAuthority();
+		return ($this->scheme ? $this->scheme . ':' : '') . (($authority = $this->getAuthority()) ? '//' . $authority : '');
 	}
 
 


### PR DESCRIPTION
Nette\Http\Url::getHostUrl() returns '//' when no scheme or host is suplied.
Which is slightly annoing for me and it goes against URI syntax 'scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]'.