### PR TITLE
Feature: Missing FileUpload::isEmpty()

### DIFF
--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -141,6 +141,15 @@ class FileUpload
 
 
 	/**
+	 * @return bool
+	 */
+	public function hasFile()
+	{
+		return $this->error !== UPLOAD_ERR_NO_FILE;
+	}
+
+
+	/**
 	 * Move uploaded file to new location.
 	 * @param  string
 	 * @return self

--- a/tests/Http/FileUpload.basic.phpt
+++ b/tests/Http/FileUpload.basic.phpt
@@ -27,6 +27,7 @@ test(function () {
 	Assert::same(__DIR__ . '/files/file.txt', (string) $upload);
 	Assert::same(0, $upload->getError());
 	Assert::true($upload->isOk());
+	Assert::true($upload->hasFile());
 	Assert::false($upload->isImage());
 	Assert::same(file_get_contents(__DIR__ . '/files/file.txt'), $upload->getContents());
 });
@@ -45,4 +46,19 @@ test(function () {
 	Assert::same('image.png', $upload->getSanitizedName());
 	Assert::same('image/png', $upload->getContentType());
 	Assert::true($upload->isImage());
+});
+
+
+test(function () {
+	$upload = new FileUpload([
+		'name' => '',
+		'type' => '',
+		'tmp_name' => '',
+		'error' => UPLOAD_ERR_NO_FILE,
+		'size' => 0,
+	]);
+
+	Assert::false($upload->isOk());
+	Assert::false($upload->hasFile());
+	Assert::false($upload->isImage());
 });


### PR DESCRIPTION
How do you feel about adding `isEmpty()` shortcut to `FileUpload`
defined as `$this->error === UPLOAD_ERR_NO_FILE`?