### PR TITLE
Session: used static access to $started

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -407,7 +407,7 @@ class Session
 
 			} else {
 				if (session_status() === PHP_SESSION_ACTIVE) {
-					throw new Nette\InvalidStateException("Unable to set 'session.$key' to value '$value' when session has been started" . ($this->started ? '.' : ' by session.auto_start or session_start().'));
+					throw new Nette\InvalidStateException("Unable to set 'session.$key' to value '$value' when session has been started" . (self::$started ? '.' : ' by session.auto_start or session_start().'));
 				}
 				if (isset($special[$key])) {
 					$key = "session_$key";


### PR DESCRIPTION
Deprecated error was triggered.
$this->started instead of self::$started was used.