### PR TITLE
Make sure __NF in session is array

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -104,6 +104,10 @@ class Session
 		*/
 		$nf = & $_SESSION['__NF'];
 
+		if (!is_array($nf)) {
+			$nf = [];
+		}
+		
 		// regenerate empty session
 		if (empty($nf['Time'])) {
 			$nf['Time'] = time();

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -107,7 +107,7 @@ class Session
 		if (!is_array($nf)) {
 			$nf = [];
 		}
-		
+
 		// regenerate empty session
 		if (empty($nf['Time'])) {
 			$nf['Time'] = time();


### PR DESCRIPTION
There is a problem that when request fails in specific moment, sessions gets destroyed and the `$nf` variable is then equal to `0`. This allows the session to recover without throwing error.