### PR TITLE
UrlScript: accept option $scriptPath param in constructor

### DIFF
--- a/src/Http/UrlScript.php
+++ b/src/Http/UrlScript.php
@@ -30,6 +30,13 @@ class UrlScript extends Url
 	private $scriptPath;
 
 
+	public function __construct($url = NULL, $scriptPath = '')
+	{
+		parent::__construct($url);
+		$this->setScriptPath($scriptPath);
+	}
+
+
 	/**
 	 * Sets the script-path part of URI.
 	 * @param  string

--- a/tests/Http/UrlScript.parse.phpt
+++ b/tests/Http/UrlScript.parse.phpt
@@ -11,9 +11,21 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-$url = new UrlScript('http://nette.org:8080/file.php?q=search');
-Assert::same('/file.php', $url->scriptPath);
-Assert::same('http://nette.org:8080/',  $url->baseUrl);
-Assert::same('/', $url->basePath);
-Assert::same('file.php?q=search',  $url->relativeUrl);
-Assert::same('',  $url->pathInfo);
+test(function () {
+	$url = new UrlScript('http://nette.org:8080/file.php?q=search');
+	Assert::same('/file.php', $url->scriptPath);
+	Assert::same('http://nette.org:8080/',  $url->baseUrl);
+	Assert::same('/', $url->basePath);
+	Assert::same('file.php?q=search',  $url->relativeUrl);
+	Assert::same('',  $url->pathInfo);
+});
+
+
+test(function () {
+	$url = new UrlScript('http://nette.org:8080/file.php?q=search', '/');
+	Assert::same('/', $url->scriptPath);
+	Assert::same('http://nette.org:8080/',  $url->baseUrl);
+	Assert::same('/', $url->basePath);
+	Assert::same('file.php?q=search',  $url->relativeUrl);
+	Assert::same('file.php',  $url->pathInfo);
+});


### PR DESCRIPTION
To alleviate the pain caused by https://github.com/nette/http/commit/12ac75cf816d21716cf4e0d58ded693e3dae7c63 I suggest adding optional parameter to UrlScript's constructor.

