### PR TITLE
Fixed Http\Response::setCode producing invalid HTTP header

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -66,8 +66,7 @@ class Response implements IResponse
 		}
 		self::checkHeaders();
 		$this->code = $code;
-		$protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.1';
-		header($protocol . ' ' . $code, TRUE, $code);
+		http_response_code($code);
 		return $this;
 	}
 


### PR DESCRIPTION
According to [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.1.2) (HTTP/1.1), the first line of a HTTP response must be:

```
 The first line of a response message is the status-line, consisting
   of the protocol version, a space (SP), the status code, another
   space, a possibly empty textual phrase describing the status code,
   and ending with CRLF.

     status-line = HTTP-version SP status-code SP reason-phrase CRLF
```

When setting a custom code through the setCode method, Nette omits this part:

> another space, a possibly empty textual phrase describing the status code

This is easily fixed by calling the `http_response_code` function that's in PHP.

We bumped into this issue when trying to call our own application with Guzzle which has a strict parsing rules of HTTP responses. [It requires the space to be there](https://github.com/guzzle/psr7/blob/master/src/functions.php#L491):

```
/**
 * Parses a response message string into a response object.
 *
 * @param string $message Response message string.
 *
 * @return Response
 */
function parse_response($message)
{
    $data = _parse_message($message);
    if (!preg_match('/^HTTP\/.* [0-9]{3} .*/', $data['start-line'])) {
        throw new \InvalidArgumentException('Invalid response string');
    }
    $parts = explode(' ', $data['start-line'], 3);

    return new Response(
        $parts[1],
        $data['headers'],
        $data['body'],
        explode('/', $parts[0])[1],
        isset($parts[2]) ? $parts[2] : null
    );
}
```