### PR TITLE
Added support for Content-Security-Policy [WIP]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"nette/utils": "^2.4"
 	},
 	"require-dev": {
-		"nette/di": "^2.4",
+		"nette/di": "^2.4.6",
 		"nette/tester": "~2.0",
 		"tracy/tracy": "^2.4"
 	},

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -71,6 +71,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 
 		$initialize = $class->getMethod('initialize');
 		$config = $this->getConfig();
+		$headers = $config['headers'];
 
 		if (isset($config['frames']) && $config['frames'] !== TRUE) {
 			$frames = $config['frames'];
@@ -79,10 +80,10 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			} elseif (preg_match('#^https?:#', $frames)) {
 				$frames = "ALLOW-FROM $frames";
 			}
-			$initialize->addBody('$this->getService(?)->setHeader(?, ?);', [$this->prefix('response'), 'X-Frame-Options', $frames]);
+			$headers['X-Frame-Options'] = $frames;
 		}
 
-		foreach ($config['headers'] as $key => $value) {
+		foreach ($headers as $key => $value) {
 			if ($value != NULL) { // intentionally ==
 				$initialize->addBody('$this->getService(?)->setHeader(?, ?);', [$this->prefix('response'), $key, $value]);
 			}


### PR DESCRIPTION
- bug fix? no   <!-- #issue numbers, if any -->
- new feature? yes
- BC break? no

config:

```neon
http:
	policy:
		script-src: nonce
		img-src: https: 
		# ...
```

### variant 1
presenter:

```php
	function beforeRender()
	{
		$this->template->nonce = $this->getHttpResponse()->getNonce();
	}
```

template:

```latte
<script src="https://www.google-analytics.com/analytics.js" async defer nonce={$nonce}></script>
```

### variant 2
presenter is not changed

```latte
<script src="https://www.google-analytics.com/analytics.js" async defer n:nonce></script>
```
