### PR TITLE
Hlepers::ipMatch() fixed warning when passed invalid IP address

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -247,7 +247,7 @@ class RequestFactory
 				if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
 					$xForwardedForWithoutProxies = array_filter(explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']), function ($ip) {
 						return !array_filter($this->proxies, function ($proxy) use ($ip) {
-							return Helpers::ipMatch(trim($ip), $proxy);
+							return filter_var(trim($ip), FILTER_VALIDATE_IP) !== FALSE && Helpers::ipMatch(trim($ip), $proxy);
 						});
 					});
 					$remoteAddr = trim(end($xForwardedForWithoutProxies));

--- a/tests/Http/RequestFactory.proxy.x-forwarded.phpt
+++ b/tests/Http/RequestFactory.proxy.x-forwarded.phpt
@@ -35,8 +35,8 @@ test(function () {
 	$_SERVER = [
 		'REMOTE_ADDR' => '10.0.0.2', //proxy2
 		'REMOTE_HOST' => 'proxy2',
-		'HTTP_X_FORWARDED_FOR' => '123.123.123.123, 172.16.0.1, 10.0.0.1',
-		'HTTP_X_FORWARDED_HOST' => 'fake, real, proxy1',
+		'HTTP_X_FORWARDED_FOR' => '123.123.123.123, not-ip.com, 172.16.0.1, 10.0.0.1',
+		'HTTP_X_FORWARDED_HOST' => 'fake, not-ip.com, real, proxy1',
 	];
 
 	$factory = new RequestFactory;


### PR DESCRIPTION
- bug fix
- no BC break

This fixes a warning which happened on our production servers. Generally, ipMatch() function should be able to handle invalid input without a warning.

The cause was an invalid header
`HTTP_X_FORWARDED_FOR: "192.168.5.237,mcd14281.lax,mcd14281.lax, 64.134.222.215, 185.152.66.10, 100.97.10.64"`
which was parsed by RequestFactory and validated against known/allowed proxies.
