### PR TITLE
RequestFactory: when proxy is used, sets default port when HTTP_X_FORWARDED_PORT is not available

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -238,6 +238,7 @@ class RequestFactory
 			} else {
 				if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
 					$url->setScheme(strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') === 0 ? 'https' : 'http');
+					$url->setPort($url->getScheme() === 'https' ? 443 : 80);
 				}
 
 				if (!empty($_SERVER['HTTP_X_FORWARDED_PORT'])) {


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

This should prevent to create links like `https://example.com:80`