### PR TITLE
Session: initialize $started property in constructor

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -26,7 +26,7 @@ class Session
 	private $regenerated = false;
 
 	/** @var bool  has been session started? */
-	private static $started;
+	private static $started = false;
 
 	/** @var array default configuration */
 	private $options = [
@@ -61,7 +61,7 @@ class Session
 	{
 		$this->request = $request;
 		$this->response = $response;
-		self::$started = (session_status() === PHP_SESSION_ACTIVE);
+		self::$started = (self::$started && session_status() === PHP_SESSION_ACTIVE);
 	}
 
 

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -26,7 +26,7 @@ class Session
 	private $regenerated = false;
 
 	/** @var bool  has been session started? */
-	private static $started = false;
+	private static $started;
 
 	/** @var array default configuration */
 	private $options = [
@@ -61,6 +61,7 @@ class Session
 	{
 		$this->request = $request;
 		$this->response = $response;
+		self::$started = (session_status() === PHP_SESSION_ACTIVE);
 	}
 
 


### PR DESCRIPTION
- bug fix? yes
- new feature? depends
- BC break? no, hopefully

This fixes the issue when new instance of DI container (with session service) is created after session has been manually aborted via `session_abort()` due to database transaction failure.