### PR TITLE
FileUpload: Add Webp to isImage

### DIFF
--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -167,7 +167,7 @@ final class FileUpload
 	 */
 	public function isImage(): bool
 	{
-		return in_array($this->getContentType(), ['image/gif', 'image/png', 'image/jpeg'], true);
+		return in_array($this->getContentType(), ['image/gif', 'image/png', 'image/jpeg', 'image/webp'], true);
 	}
 
 


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no

According to content types in `Nette\Utils\Image` added `image/webp` to `isImage()` method.
