### PR TITLE
Take session ID from session_id() instead of cookie.

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -77,7 +77,8 @@ class Session
 
 		$id = session_id();
 		if (!is_string($id) || !preg_match('#^[0-9a-zA-Z,-]{22,256}\z#i', $id)) {
-			session_id('');
+			$newId = PHP_VERSION_ID >= 70100 ? session_create_id() : Nette\Utils\Random::generate(128);
+			session_id($newId);
 		}
 
 		try {

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -75,11 +75,9 @@ class Session
 
 		$this->configure($this->options);
 
-		$id = $this->request->getCookie(session_name());
-		if (is_string($id) && preg_match('#^[0-9a-zA-Z,-]{22,256}\z#i', $id)) {
-			session_id($id);
-		} else {
-			unset($_COOKIE[session_name()]);
+		$id = session_id();
+		if (!is_string($id) || !preg_match('#^[0-9a-zA-Z,-]{22,256}\z#i', $id)) {
+			session_id('');
 		}
 
 		try {
@@ -165,6 +163,7 @@ class Session
 			$this->clean();
 			session_write_close();
 			self::$started = false;
+                        $this->regenerated = false;
 		}
 	}
 
@@ -195,7 +194,7 @@ class Session
 	 */
 	public function exists()
 	{
-		return self::$started || $this->request->getCookie($this->getName()) !== null;
+		return self::$started || session_id() !== '';
 	}
 
 

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -164,7 +164,7 @@ class Session
 			$this->clean();
 			session_write_close();
 			self::$started = false;
-                        $this->regenerated = false;
+			$this->regenerated = false;
 		}
 	}
 

--- a/tests/Http/Session.invalidId.phpt
+++ b/tests/Http/Session.invalidId.phpt
@@ -12,6 +12,7 @@ require __DIR__ . '/../bootstrap.php';
 
 
 $_COOKIE['PHPSESSID'] = '#';
+session_id('#');
 
 
 $session = new Session(new Nette\Http\Request(new Nette\Http\UrlScript), new Nette\Http\Response);

--- a/tests/Http/Session.regenerate-empty-session.phpt
+++ b/tests/Http/Session.regenerate-empty-session.phpt
@@ -13,10 +13,11 @@ require __DIR__ . '/../bootstrap.php';
 
 
 // create fake session
-$cookies = ['PHPSESSID' => $sessionId = md5('3')];
+$sessionId = md5('3');
+session_id($sessionId);
 file_put_contents(TEMP_DIR . '/sess_' . $sessionId, '__NF|a:1:{s:4:"DATA";a:1:{s:4:"temp";a:1:{s:5:"value";s:3:"yes";}}}');
 
-$session = new Session(new Http\Request(new Http\UrlScript('http://nette.org'), null, [], [], $cookies), new Http\Response);
+$session = new Session(new Http\Request(new Http\UrlScript), new Http\Response);
 $session->start();
 Assert::same('yes', $session->getSection('temp')->value);
 

--- a/tests/Http/Session.restart-after-regenerate.phpt
+++ b/tests/Http/Session.restart-after-regenerate.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Nette\Http\Session accepts cookie from Http\IRequest
+ * Test: Nette\Http\Session is preserved after regenerateId and restarting
  */
 
 use Nette\Http;
@@ -25,8 +25,16 @@ Assert::same($sessionId, $session->getId());
 Assert::same(['PHPSESSID' => $leet], $_COOKIE);
 
 Assert::same('yes', $session->getSection('temp')->value);
+$session->regenerateId();
+Assert::notSame($sessionId, $session->getId());
+$newSessionId = session_id();
+Assert::same($newSessionId, $session->getId());
 $session->close();
 
-// session was not regenerated
-Assert::true(file_exists(TEMP_DIR . '/sess_' . $sessionId));
+$session->start();
+Assert::same('yes', $session->getSection('temp')->value);
+Assert::same($newSessionId, $session->getId());
+
+// new session still exists
+Assert::true(file_exists(TEMP_DIR . '/sess_' . $newSessionId));
 Assert::count(1, glob(TEMP_DIR . '/sess_*'));


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

Fixes https://github.com/nette/http/issues/129
Session ID is taken from `session_id()` instead of cookie.
