### PR TITLE
Cannot set session cookie parameters for already started session

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -401,10 +401,12 @@ class Session
 		}
 
 		if (isset($cookie)) {
-			session_set_cookie_params(
-				$cookie['lifetime'], $cookie['path'], $cookie['domain'],
-				$cookie['secure'], $cookie['httponly']
-			);
+			if (!self::$started) {
+				session_set_cookie_params(
+					$cookie['lifetime'], $cookie['path'], $cookie['domain'],
+					$cookie['secure'], $cookie['httponly']
+				);
+			}
 			if (self::$started) {
 				$this->sendCookie();
 			}


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? probably not

Fixes `Warning session_set_cookie_params(): Cannot change session cookie parameters when session is active`
It happens when Session::setOptions() is called multiple times.
Can be tested with php 7.2+ only. In previous versions it failed silently (see https://bugs.php.net/bug.php?id=75650&thanks=2)
