### PR TITLE
HttpExtension: allow setup CSP in report only mode

### DIFF
--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -95,6 +95,13 @@ class HttpExtension extends Nette\DI\CompilerExtension
 		}
 
 		if (!empty($config['csp'])) {
+			$reportOnly = false;
+
+			if (array_key_exists('reportOnly', $config['csp'])) {
+				$reportOnly = $config['csp']['reportOnly'];
+				unset($config['csp']['reportOnly']);
+			}
+
 			$value = '';
 			foreach ($config['csp'] as $type => $policy) {
 				$value .= $type;
@@ -109,7 +116,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 					["'nonce", "'nonce-", $value]
 				);
 			}
-			$headers['Content-Security-Policy'] = $value;
+			$headers['Content-Security-Policy' . ($reportOnly ? '-Report-Only' : '')] = $value;
 		}
 
 		foreach ($headers as $key => $value) {

--- a/tests/Http.DI/HttpExtension.reportOnly.phpt
+++ b/tests/Http.DI/HttpExtension.reportOnly.phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: HttpExtension.
+ */
+
+declare(strict_types=1);
+
+use Nette\Bridges\HttpDI\HttpExtension;
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+if (PHP_SAPI === 'cli') {
+	Tester\Environment::skip('Headers are not testable in CLI mode');
+}
+
+
+$compiler = new DI\Compiler;
+$compiler->addExtension('http', new HttpExtension);
+$loader = new DI\Config\Loader;
+$config = $loader->load(Tester\FileMock::create(<<<'EOD'
+http:
+	csp:
+		reportOnly: true
+		default-src: "'self' https://example.com"
+		report-uri: https://example.com/report
+EOD
+, 'neon'));
+
+eval($compiler->addConfig($config)->compile());
+
+$container = new Container;
+$container->initialize();
+
+$headers = headers_list();
+
+Assert::contains("Content-Security-Policy-Report-Only: default-src 'self' https://example.com; report-uri https://example.com/report;", $headers);
+
+
+echo ' '; @ob_flush(); flush();
+
+Assert::true(headers_sent());
+
+Assert::exception(function () use ($container) {
+	$container->initialize();
+}, Nette\InvalidStateException::class, 'Cannot send header after %a%');


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: will do if accepted

CSP can now be enabled in report only mode. PR to nette/application will be sent in just a minute.
