### PR TITLE
RequestFactory: SERVER_NAME has higher priority over HTTP_HOST

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -70,7 +70,7 @@ class RequestFactory
 
 		// host & port
 		if (
-			(isset($_SERVER[$tmp = 'HTTP_HOST']) || isset($_SERVER[$tmp = 'SERVER_NAME']))
+			(isset($_SERVER[$tmp = 'SERVER_NAME']) || isset($_SERVER[$tmp = 'HTTP_HOST']))
 			&& preg_match('#^([a-z0-9_.-]+|\[[a-f0-9:]+\])(:\d+)?\z#i', $_SERVER[$tmp], $pair)
 		) {
 			$url->setHost(strtolower($pair[1]));


### PR DESCRIPTION
- bug fix 
- BC break? yes

Hi,
it is better to identify server host name by secure directive SERVER_NAME, because HTTP_HOST is not secure and can be changed by user.
https://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html