### PR TITLE
Feature-Policy header

### DIFF
--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -103,7 +103,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			foreach ($policyConfig as $type => $policy) {
 				$value .= $type;
 				foreach ((array) $policy as $item) {
-					$value .= (preg_match('#[.:]#', $item) || in_array($type, $nonQuoted, true)) ? " $item" : " '$item'";
+					$value .= (preg_match('#[.:*]#', $item) || in_array($type, $nonQuoted, true)) ? " $item" : " '$item'";
 				}
 				$value .= '; ';
 			}

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -98,7 +98,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 
 		// function to create CSP and FP header value from configuration array
 		$createValue = static function (array $policyConfig) {
-			static $nonQuoted = [ 'require-sri-for', 'sandbox' ]; // those properties contain non quoted keywords
+			static $nonQuoted = [ 'require-sri-for', 'sandbox', 'plugin-types' ]; // those properties contain non quoted keywords
 			$value = '';
 			foreach ($policyConfig as $type => $policy) {
 				$value .= $type;

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -26,6 +26,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 		'frames' => 'SAMEORIGIN', // X-Frame-Options
 		'csp' => [], // Content-Security-Policy
 		'csp-report' => [], // Content-Security-Policy-Report-Only
+		'fp' => [], // Feature-Policy
 	];
 
 	/** @var bool */
@@ -114,6 +115,18 @@ class HttpExtension extends Nette\DI\CompilerExtension
 				);
 			}
 			$headers['Content-Security-Policy' . ($key === 'csp' ? '' : '-Report-Only')] = $value;
+		}
+		
+		if (!empty($config['fp'])) {
+            		$value = '';
+            		foreach ($config['fp'] as $type => $policy) {
+                		$value .= $type;
+				foreach ((array) $policy as $item) {
+				    $value .= preg_match('#^[a-z-]+\z#', $item) ? " '$item'" : " $item";
+				}
+				$value .= '; ';
+            		}
+            		$headers['Feature-Policy'] = $value;
 		}
 
 		foreach ($headers as $key => $value) {

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -98,16 +98,12 @@ class HttpExtension extends Nette\DI\CompilerExtension
 
 		// function to create CSP and FP header value from configuration array
 		$createValue = static function (array $policyConfig) {
-			static $nonQuoted = [
-				'script', 'style', // require-sri-for
-				'allow-forms', 'allow-modals', 'allow-orientation-lock', 'allow-pointer-lock', 'allow-popups', 'allow-scripts',
-				'allow-popups-to-escape-sandbox', 'allow-presentation', 'allow-same-origin', 'allow-top-navigation', // sandbox
-			];
+			static $nonQuoted = [ 'require-sri-for', 'sandbox' ]; // those properties contain non quoted keywords
 			$value = '';
 			foreach ($policyConfig as $type => $policy) {
 				$value .= $type;
 				foreach ((array) $policy as $item) {
-					$value .= (preg_match('#^[a-z-]+\z#', $item) && !in_array($item, $nonQuoted, true)) ? " '$item'" : " $item";
+					$value .= (preg_match('#[.:]#', $item) || in_array($type, $nonQuoted, true)) ? " $item" : " '$item'";
 				}
 				$value .= '; ';
 			}


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: None ATM

Přidává hlavičku Feature-Policy.
Header ještě není schválený standard, ale jediné nad čím se váhá je, jaké featury budou prohlížeče implementovat.

Syntax stejná jako Content-Security-Policy, prakticky jsem jen použil existující kod.

Hlavička Feature-Policy-Report-Only zatím neexistuje a co vím ani se o ní nepřemýšlí.