### PR TITLE
Require-sri-for speciální CSP pravidlo

### DIFF
--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -103,7 +103,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			foreach ($config[$key] as $type => $policy) {
 				$value .= $type;
 				foreach ((array) $policy as $item) {
-					$value .= preg_match('#^[a-z-]+\z#', $item) ? " '$item'" : " $item";
+					$value .= (preg_match('#^[a-z-]+\z#', $item) && $type !== 'require-sri-for') ? " '$item'" : " $item";
 				}
 				$value .= '; ';
 			}


### PR DESCRIPTION
- bug fix / new feature - tak trochu obojí
- BC break? no
- doc PR: None ATM

[https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for)

Speciální záznam pro CSP, který ukazuje pro který content má prohlížeč vyžadovat subresource integrity.

```
csp
    require-sri-for: [ script, style ]
```
Při použití tohoto pravidla v konfigu nette vloží uvozovky kolem `script` a `style` - protože se dávají kolem `none`, `self` a dalších klíčovách slov. Bohužel očekávané je nekonzistetní bez uvozovek, chrome uvozovky nezkousne.

Přidal jsem kontrolu zdali se jedná o typ `require-sri-for` a pokud ano nedají se uvozovky.