### PR TITLE
HttpExtension: X-Frame-Options header

### DIFF
--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -85,7 +85,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 		$config = $this->getConfig();
 		$headers = $config['headers'];
 
-		if (isset($config['frames']) && $config['frames'] !== true) {
+		if (isset($config['frames']) && $config['frames'] !== true && !isset($headers['X-Frame-Options'])) {
 			$frames = $config['frames'];
 			if ($frames === false) {
 				$frames = 'DENY';


### PR DESCRIPTION
- new feature
- BC break? no

Avoid processing `frames` config if header `X-Frame-Options` is already set in configuration. If `X-Frame-Options` header is already set, there is unnecessary invocation of `preg_match`, etc. This `frames` key option should not be processed at all in this case.
