### PR TITLE
SessionExtension: added option handler to pass own SessionHandlerInterface

### DIFF
--- a/src/Bridges/HttpDI/SessionExtension.php
+++ b/src/Bridges/HttpDI/SessionExtension.php
@@ -21,6 +21,7 @@ class SessionExtension extends Nette\DI\CompilerExtension
 		'debugger' => false,
 		'autoStart' => 'smart', // true|false|smart
 		'expiration' => null,
+		'handler' => null,
 	];
 
 	/** @var bool */
@@ -49,6 +50,9 @@ class SessionExtension extends Nette\DI\CompilerExtension
 		if ($config['expiration']) {
 			$session->addSetup('setExpiration', [$config['expiration']]);
 		}
+		if ($config['handler']) {
+			$session->addSetup('setHandler', [$config['handler']]);
+		}
 		if (($config['cookieDomain'] ?? null) === 'domain') {
 			$config['cookieDomain'] = $builder::literal('$this->getByType(Nette\Http\IRequest::class)->getUrl()->getDomain(2)');
 		}
@@ -62,7 +66,7 @@ class SessionExtension extends Nette\DI\CompilerExtension
 			]);
 		}
 
-		unset($config['expiration'], $config['autoStart'], $config['debugger']);
+		unset($config['expiration'], $config['handler'], $config['autoStart'], $config['debugger']);
 		if (!empty($config)) {
 			$session->addSetup('setOptions', [$config]);
 		}

--- a/tests/Http.DI/SessionExtension.handler.phpt
+++ b/tests/Http.DI/SessionExtension.handler.phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: SessionExtension.
+ */
+
+declare(strict_types=1);
+
+use Nette\Bridges\HttpDI\HttpExtension;
+use Nette\Bridges\HttpDI\SessionExtension;
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class TestHandler extends SessionHandler
+{
+	public $called = false;
+
+	public function open($save_path, $session_name)
+	{
+		$this->called = true;
+		return parent::open($save_path, $session_name);
+	}
+}
+
+
+$compiler = new DI\Compiler;
+$compiler->addExtension('foo', new HttpExtension);
+$compiler->addExtension('session', new SessionExtension(false, PHP_SAPI === 'cli'));
+
+$loader = new DI\Config\Loader;
+$config = $loader->load(Tester\FileMock::create('
+session:
+	handler: @handler
+
+services:
+	foo.request: Nette\Http\Request(Nette\Http\UrlScript("http://www.nette.org"))
+	handler: TestHandler
+', 'neon'));
+
+eval($compiler->addConfig($config)->compile());
+
+$container = new Container;
+$container->getService('session')->start();
+
+Assert::true($container->getService('handler')->called);


### PR DESCRIPTION
- new feature
- BC break? no

Own session handler cannot be set via `session.save_handler`, the `ini_set()` accepts string type only.
Can be solved by decorator extension:
```neon
decorator:
    Nette\Http\Session:
        setup:
            - setHandler(...)
```
but propesed way seems more suitable to me.