### PR TITLE
Response, IResponse: unified API (BC break)

### DIFF
--- a/src/Http/IResponse.php
+++ b/src/Http/IResponse.php
@@ -88,7 +88,7 @@ interface IResponse
 	 * Sets HTTP response code.
 	 * @return static
 	 */
-	function setCode(int $code);
+	function setCode(int $code, ?string $reason = null);
 
 	/**
 	 * Returns HTTP response code.
@@ -99,7 +99,7 @@ interface IResponse
 	 * Sends a HTTP header and replaces a previous one.
 	 * @return static
 	 */
-	function setHeader(string $name, string $value);
+	function setHeader(string $name, ?string $value);
 
 	/**
 	 * Adds HTTP header.
@@ -111,7 +111,7 @@ interface IResponse
 	 * Sends a Content-type HTTP header.
 	 * @return static
 	 */
-	function setContentType(string $type, string $charset = null);
+	function setContentType(string $type, ?string $charset = null);
 
 	/**
 	 * Redirects to a new URL.
@@ -144,10 +144,10 @@ interface IResponse
 	 * @param  string|int|\DateTimeInterface $expire  time, value 0 means "until the browser is closed"
 	 * @return static
 	 */
-	function setCookie(string $name, string $value, $expire, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null);
+	function setCookie(string $name, string $value, $expire, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null);
 
 	/**
 	 * Deletes a cookie.
 	 */
-	function deleteCookie(string $name, string $path = null, string $domain = null, bool $secure = null);
+	function deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null);
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -58,7 +58,7 @@ final class Response implements IResponse
 	 * @throws Nette\InvalidArgumentException  if code is invalid
 	 * @throws Nette\InvalidStateException  if HTTP headers have been sent
 	 */
-	public function setCode(int $code, string $reason = null)
+	public function setCode(int $code, ?string $reason = null)
 	{
 		if ($code < 100 || $code > 599) {
 			throw new Nette\InvalidArgumentException("Bad HTTP response '$code'.");
@@ -129,7 +129,7 @@ final class Response implements IResponse
 	 * @return static
 	 * @throws Nette\InvalidStateException  if HTTP headers have been sent
 	 */
-	public function setContentType(string $type, string $charset = null)
+	public function setContentType(string $type, ?string $charset = null)
 	{
 		$this->setHeader('Content-Type', $type . ($charset ? '; charset=' . $charset : ''));
 		return $this;
@@ -235,7 +235,7 @@ final class Response implements IResponse
 	 * @return static
 	 * @throws Nette\InvalidStateException  if HTTP headers have been sent
 	 */
-	public function setCookie(string $name, string $value, $time, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null, string $sameSite = null)
+	public function setCookie(string $name, string $value, $time, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null, ?string $sameSite = null)
 	{
 		self::checkHeaders();
 		$options = [
@@ -267,7 +267,7 @@ final class Response implements IResponse
 	 * Deletes a cookie.
 	 * @throws Nette\InvalidStateException  if HTTP headers have been sent
 	 */
-	public function deleteCookie(string $name, string $path = null, string $domain = null, bool $secure = null): void
+	public function deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null): void
 	{
 		$this->setCookie($name, '', 0, $path, $domain, $secure);
 	}


### PR DESCRIPTION
- bug fix / new feature? a bit of both
- BC break? yes
- doc PR: don't think it's needed

`Response` API at the moment slightly differs from `IResponse`. This PR unifies both APIs. Also, explicitly marking all nullable parameters as nullable in parameter type hint.