### PR TITLE
HTTPS and mod_remoteip

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -265,8 +265,17 @@ class RequestFactory
 					}
 				}
 			}
-		}
+		} else {
+			if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+				$url->setScheme(strcasecmp($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') === 0 ? 'https' : 'http');
+				$url->setPort($url->getScheme() === 'https' ? 443 : 80);
+			}
 
+			if (!empty($_SERVER['HTTP_X_FORWARDED_PORT'])) {
+				$url->setPort((int) $_SERVER['HTTP_X_FORWARDED_PORT']);
+			}
+		}
+		
 		// method, eg. GET, PUT, ...
 		$method = $_SERVER['REQUEST_METHOD'] ?? null;
 		if (


### PR DESCRIPTION
- bug fix
- BC break? no

I have web server setup with HTTP proxy and Apache web server with module mod_remoteip (This mod replace REMOTE_ADDR to real client IP instead of proxy IP). 
HTTP works as expected but with HTTPS I have these problems:

With router:
`$router[] = new Route('<presenter>/<action>[/<id>]', 'Dashboard:default');`
Result URL was `https://example.com:80/`

With router:
`$router[] = new Route('https://%host%/<presenter>/<action>[/<id>]', 'Dashboard:default');`
Result in browser was redirect loop (`ERR_TOO_MANY_REDIRECTS`)

I searched in code and found that HTTP_X_FORWARDED* headers are ignored if they din't come from trusted proxy. After bypassing this check for HTTP_X_FORWARDED_PROTO and HTTP_X_FORWARDED_PORT router works again as expected.
I don't see any security problem if these two variables didn't come from trusted proxy.