### PR TITLE
Configure headers in response setup

### DIFF
--- a/tests/Http.DI/HttpExtension.csp.phpt
+++ b/tests/Http.DI/HttpExtension.csp.phpt
@@ -45,7 +45,7 @@ EOD
 eval($compiler->addConfig($config)->compile());
 
 $container = new Container;
-$container->initialize();
+$container->getService('http.response');
 
 $headers = headers_list();
 
@@ -59,5 +59,5 @@ echo ' '; @ob_flush(); flush();
 Assert::true(headers_sent());
 
 Assert::exception(function () use ($container) {
-	$container->initialize();
+	$container->createService('http.response');
 }, Nette\InvalidStateException::class, 'Cannot send header after %a%');

--- a/tests/Http.DI/HttpExtension.defaultHeaders.phpt
+++ b/tests/Http.DI/HttpExtension.defaultHeaders.phpt
@@ -23,7 +23,7 @@ $compiler->addExtension('http', new HttpExtension);
 eval($compiler->compile());
 
 $container = new Container;
-$container->initialize();
+$container->getService('http.response');
 
 $headers = headers_list();
 Assert::contains('X-Frame-Options: SAMEORIGIN', $headers);

--- a/tests/Http.DI/HttpExtension.featurePolicy.phpt
+++ b/tests/Http.DI/HttpExtension.featurePolicy.phpt
@@ -35,7 +35,7 @@ EOD
 eval($compiler->addConfig($config)->compile());
 
 $container = new Container;
-$container->initialize();
+$container->getService('http.response');
 
 $headers = headers_list();
 var_dump($headers);
@@ -48,5 +48,5 @@ echo ' '; @ob_flush(); flush();
 Assert::true(headers_sent());
 
 Assert::exception(function () use ($container) {
-	$container->initialize();
+	$container->createService('http.response');
 }, Nette\InvalidStateException::class, 'Cannot send header after %a%');

--- a/tests/Http.DI/HttpExtension.headers.phpt
+++ b/tests/Http.DI/HttpExtension.headers.phpt
@@ -33,7 +33,7 @@ EOD
 eval($compiler->addConfig($config)->compile());
 
 $container = new Container;
-$container->initialize();
+$container->getService('http.response');
 
 $headers = headers_list();
 Assert::contains('X-Frame-Options: SAMEORIGIN', $headers);
@@ -49,5 +49,5 @@ echo ' '; @ob_flush(); flush();
 Assert::true(headers_sent());
 
 Assert::exception(function () use ($container) {
-	$container->initialize();
+	$container->createService('http.response');
 }, Nette\InvalidStateException::class, 'Cannot send header after %a%');

--- a/tests/Http.DI/HttpExtension.sameSiteProtection.phpt
+++ b/tests/Http.DI/HttpExtension.sameSiteProtection.phpt
@@ -21,7 +21,7 @@ $compiler->addExtension('http', new HttpExtension);
 eval($compiler->compile());
 
 $container = new Container;
-$container->initialize();
+$container->getService('http.response');
 
 $headers = headers_list();
 Assert::contains(


### PR DESCRIPTION
- BC break: no
- doc PR: not needed

Moved headers configuration from initialize() method of DIC to Response service setup.
Useful for applications with multiple http layer implementations (we use psr-7 in Apitte). It should prevent mixing headers from nette/http if not used for current request