### PR TITLE
Include "empty" hostname ('0') in the host URL

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -324,7 +324,7 @@ class Url implements \JsonSerializable
 	public function getHostUrl(): string
 	{
 		return ($this->scheme ? $this->scheme . ':' : '')
-			. (($authority = $this->getAuthority()) ? '//' . $authority : '');
+			. (($authority = $this->getAuthority()) !== '' ? '//' . $authority : '');
 	}
 
 

--- a/src/Http/UrlImmutable.php
+++ b/src/Http/UrlImmutable.php
@@ -281,7 +281,7 @@ class UrlImmutable implements \JsonSerializable
 	public function getHostUrl(): string
 	{
 		return ($this->scheme ? $this->scheme . ':' : '')
-			. ($this->authority ? '//' . $this->authority : '');
+			. ($this->authority !== '' ? '//' . $this->authority : '');
 	}
 
 

--- a/tests/Http/Url.httpScheme.phpt
+++ b/tests/Http/Url.httpScheme.phpt
@@ -55,3 +55,6 @@ Assert::same('?arg=value#anchor', $url->absoluteUrl);
 
 $url->setPath('');
 Assert::same('', $url->getPath());
+
+$url = new Url('https://0/0');
+Assert::same('https://0', $url->hostUrl);

--- a/tests/Http/UrlImmutable.Url.phpt
+++ b/tests/Http/UrlImmutable.Url.phpt
@@ -32,3 +32,6 @@ Assert::same('anchor', $url->fragment);
 Assert::same('username%3A:password%3A@hostname:60', $url->authority);
 Assert::same('http://username%3A:password%3A@hostname:60', $url->hostUrl);
 Assert::same('http://username%3A:password%3A@hostname:60/p%61th/script.php?arg=value#anchor', $url->absoluteUrl);
+
+$url = new UrlImmutable('https://0/0');
+Assert::same('https://0', $url->hostUrl);


### PR DESCRIPTION
- bug fix?  yes #158
- BC break? no

Include "empty" hostname (`0`) in the host URL

Fix #158