### PR TITLE
Extension: Cookie "nette-samesite" should be secured in case of HTTPS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4snapshot
 
 env:
     - PHP_BIN=php

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 	"minimum-stability": "dev",
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.0-dev"
+			"dev-master": "4.0-dev"
 		}
 	}
 }

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -123,7 +123,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			}
 		}
 
-		$code[] = Helpers::formatArgs('$response->setCookie(...?);', [['nette-samesite', '1', 0, '/', null, null, true, 'Strict']]);
+		$code[] = Helpers::formatArgs('$response->setCookie(...?);', [['nette-samesite', '1', 0, '/', null, $config->cookieSecure === true ? true : null, true, 'Strict']]);
 
 		$initialize->addBody("(function () {\n\t" . implode("\n\t", $code) . "\n})();");
 	}

--- a/src/Http/IResponse.php
+++ b/src/Http/IResponse.php
@@ -182,11 +182,6 @@ interface IResponse
 	function setExpiration(?string $expire);
 
 	/**
-	 * Checks if headers have been sent.
-	 */
-	function isSent(): bool;
-
-	/**
 	 * Returns value of an HTTP header.
 	 */
 	function getHeader(string $header): ?string;

--- a/src/Http/IResponse.php
+++ b/src/Http/IResponse.php
@@ -16,12 +16,6 @@ namespace Nette\Http;
  */
 interface IResponse
 {
-	/** @deprecated */
-	public const PERMANENT = 2116333333;
-
-	/** @deprecated */
-	public const BROWSER = 0;
-
 	/** HTTP 1.1 response code */
 	public const
 		S100_CONTINUE = 100,

--- a/src/Http/IResponse.php
+++ b/src/Http/IResponse.php
@@ -193,6 +193,7 @@ interface IResponse
 
 	/**
 	 * Returns a associative array of headers to sent.
+	 * @return string[][]
 	 */
 	function getHeaders(): array;
 

--- a/src/Http/IResponse.php
+++ b/src/Http/IResponse.php
@@ -12,7 +12,6 @@ namespace Nette\Http;
 
 /**
  * HTTP response interface.
- * @method self deleteHeader(string $name)
  */
 interface IResponse
 {
@@ -142,6 +141,17 @@ interface IResponse
 	];
 
 	/**
+	 * Sets HTTP protocol version.
+	 * @return static
+	 */
+	function setProtocolVersion(string $version);
+
+	/**
+	 * Returns HTTP protocol version.
+	 */
+	function getProtocolVersion(): string;
+
+	/**
 	 * Sets HTTP response code.
 	 * @return static
 	 */
@@ -151,6 +161,11 @@ interface IResponse
 	 * Returns HTTP response code.
 	 */
 	function getCode(): int;
+
+	/**
+	 * Returns HTTP reason phrase.
+	 */
+	function getReasonPhrase(): string;
 
 	/**
 	 * Sends a HTTP header and replaces a previous one.
@@ -163,6 +178,11 @@ interface IResponse
 	 * @return static
 	 */
 	function addHeader(string $name, string $value);
+
+	/**
+	 * @return static
+	 */
+	function deleteHeader(string $name);
 
 	/**
 	 * Sends a Content-type HTTP header.
@@ -197,10 +217,21 @@ interface IResponse
 	 * @param  string|int|\DateTimeInterface $expire  time, value 0 means "until the browser is closed"
 	 * @return static
 	 */
-	function setCookie(string $name, string $value, $expire, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null);
+	function setCookie(string $name, string $value, $expire, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null, string $sameSite = null);
 
 	/**
 	 * Deletes a cookie.
 	 */
 	function deleteCookie(string $name, string $path = null, string $domain = null, bool $secure = null);
+
+	/**
+	 * @param  string|\Closure  $body
+	 * @return static
+	 */
+	function setBody($body);
+
+	/**
+	 * @return string|\Closure
+	 */
+	function getBody();
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -108,8 +108,6 @@ class Request implements IRequest
 	{
 		if (func_num_args() === 0) {
 			return $this->url->getQueryParameters();
-		} elseif (func_num_args() > 1) {
-			trigger_error(__METHOD__ . '() parameter $default is deprecated, use operator ??', E_USER_DEPRECATED);
 		}
 		return $this->url->getQueryParameter($key);
 	}
@@ -124,8 +122,6 @@ class Request implements IRequest
 	{
 		if (func_num_args() === 0) {
 			return $this->post;
-		} elseif (func_num_args() > 1) {
-			trigger_error(__METHOD__ . '() parameter $default is deprecated, use operator ??', E_USER_DEPRECATED);
 		}
 		return $this->post[$key] ?? null;
 	}
@@ -156,9 +152,6 @@ class Request implements IRequest
 	 */
 	public function getCookie(string $key)
 	{
-		if (func_num_args() > 1) {
-			trigger_error(__METHOD__ . '() parameter $default is deprecated, use operator ??', E_USER_DEPRECATED);
-		}
 		return $this->cookies[$key] ?? null;
 	}
 
@@ -199,9 +192,6 @@ class Request implements IRequest
 	 */
 	public function getHeader(string $header): ?string
 	{
-		if (func_num_args() > 1) {
-			trigger_error(__METHOD__ . '() parameter $default is deprecated, use operator ??', E_USER_DEPRECATED);
-		}
 		$header = strtolower($header);
 		return $this->headers[$header] ?? null;
 	}

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -187,9 +187,6 @@ final class Response implements IResponse
 	 */
 	public function getHeader(string $header): ?string
 	{
-		if (func_num_args() > 1) {
-			trigger_error(__METHOD__ . '() parameter $default is deprecated, use operator ??', E_USER_DEPRECATED);
-		}
 		$header .= ':';
 		$len = strlen($header);
 		foreach (headers_list() as $item) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -200,13 +200,14 @@ final class Response implements IResponse
 
 	/**
 	 * Returns a associative array of headers to sent.
+	 * @return string[][]
 	 */
 	public function getHeaders(): array
 	{
 		$headers = [];
 		foreach (headers_list() as $header) {
-			$a = strpos($header, ':');
-			$headers[substr($header, 0, $a)] = (string) substr($header, $a + 2);
+			$pair = explode(': ', $header);
+			$headers[$pair[0]][] = $pair[1];
 		}
 		return $headers;
 	}

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -271,4 +271,30 @@ final class Response implements IResponse
 	{
 		return $this->body;
 	}
+
+
+	public function __toString(): string
+	{
+		$res = "HTTP/$this->version $this->code $this->reason\r\n";
+		foreach ($this->headers as $name => $info) {
+			foreach ($info[1] as $value) {
+				$res .= $info[0] . ': ' . $value . "\r\n";
+			}
+		}
+
+		if (is_string($this->body)) {
+			$res .= "\r\n" . $this->body;
+		} else {
+			ob_start(function () {});
+			try {
+				($this->body)();
+				$res .= "\r\n" . ob_get_clean();
+			} catch (\Throwable $e) {
+				ob_end_clean();
+				throw $e;
+			}
+		}
+
+		return $res;
+	}
 }

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Http;
+
+use Nette;
+
+
+/**
+ * Sends a Http\Response for a PHP SAPI environment.
+ */
+final class ResponseEmitter
+{
+	use Nette\SmartObject;
+
+	/** @var bool Whether warn on possible problem with data in output buffer */
+	public $warnOnBuffer = true;
+
+	/** @var bool  Send invisible garbage for IE? */
+	public $fixIE = true;
+
+
+	public function send(IResponse $response)
+	{
+		$this->sendHeaders($response);
+		$this->sendBody($response);
+	}
+
+
+	public function sendHeaders(IResponse $response): void
+	{
+		$this->checkHeaders();
+
+		header('HTTP/' . $response->getProtocolVersion() . ' ' . $response->getCode() . ' ' . ($response->getReasonPhrase() ?: 'Unknown status'));
+
+		foreach (headers_list() as $header) {
+			header_remove(explode(':', $header)[0]);
+		}
+
+		foreach ($response->getHeaders() as $name => $values) {
+			if (strcasecmp($name, 'Content-Length') === 0 && ini_get('zlib.output_compression')) {
+				continue; // ignore, PHP bug #44164
+			}
+			foreach ($values as $value) {
+				header($name . ': ' . $value, false);
+			}
+		}
+	}
+
+
+	public function sendBody(IResponse $response): void
+	{
+		$body = $response->getBody();
+		if (is_string($body)) {
+			echo $body;
+		} else {
+			flush();
+			$body();
+		}
+
+		if (
+			$this->fixIE
+			&& strpos($_SERVER['HTTP_USER_AGENT'] ?? '', 'MSIE ') !== false
+			&& in_array($response->getCode(), [400, 403, 404, 405, 406, 408, 409, 410, 500, 501, 505], true)
+			&& preg_match('#^text/html(?:;|$)#', (string) $response->getHeader('Content-Type'))
+		) {
+			echo Nette\Utils\Random::generate(2000, " \t\r\n"); // sends invisible garbage for IE
+		}
+	}
+
+
+	private function checkHeaders(): void
+	{
+		if (PHP_SAPI === 'cli') {
+			// ok
+		} elseif (headers_sent($file, $line)) {
+			throw new Nette\InvalidStateException('Cannot send header after HTTP headers have been sent' . ($file ? " (output started at $file:$line)." : '.'));
+
+		} elseif (
+			$this->warnOnBuffer &&
+			ob_get_length() &&
+			!array_filter(ob_get_status(true), function (array $i): bool { return !$i['chunk_size']; })
+		) {
+			trigger_error('Possible problem: you are sending a HTTP header while already having some data in output buffer. Try Tracy\OutputDebugger or start session earlier.');
+		}
+	}
+}

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Http;
+
+use Nette;
+
+
+/**
+ * HTTP response factories.
+ */
+final class ResponseFactory
+{
+	use Nette\SmartObject;
+
+	public function fromGlobals(): Response
+	{
+		$response = new Response;
+		if (is_int($code = http_response_code())) {
+			$response->setCode($code);
+		}
+		$protocol = $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1';
+		$response->setProtocolVersion(explode('/', $protocol)[1]);
+		$this->parseHeaders($response, headers_list());
+		return $response;
+	}
+
+
+	private function parseHeaders(Response $response, array $headers): void
+	{
+		foreach ($headers as $header) {
+			$parts = explode(': ', $header, 2);
+			$response->addHeader($parts[0], $parts[1]);
+		}
+	}
+}

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -461,15 +461,6 @@ class Session
 
 
 	/**
-	 * @deprecated
-	 */
-	public function getCookieParameters(): array
-	{
-		return session_get_cookie_params();
-	}
-
-
-	/**
 	 * Sets path of the directory used to save session data.
 	 * @return static
 	 */

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -259,9 +259,6 @@ class Url implements \JsonSerializable
 	 */
 	public function getQueryParameter(string $name)
 	{
-		if (func_num_args() > 1) {
-			trigger_error(__METHOD__ . '() parameter $default is deprecated, use operator ??', E_USER_DEPRECATED);
-		}
 		return $this->query[$name] ?? null;
 	}
 

--- a/tests/Http.DI/HttpExtension.defaultHeaders.phpt
+++ b/tests/Http.DI/HttpExtension.defaultHeaders.phpt
@@ -13,10 +13,6 @@ use Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
 
-if (PHP_SAPI === 'cli') {
-	Tester\Environment::skip('Headers are not testable in CLI mode');
-}
-
 
 $compiler = new DI\Compiler;
 $compiler->addExtension('http', new HttpExtension);
@@ -25,7 +21,10 @@ eval($compiler->compile());
 $container = new Container;
 $container->initialize();
 
-$headers = headers_list();
-Assert::contains('X-Frame-Options: SAMEORIGIN', $headers);
-Assert::contains('Content-Type: text/html; charset=utf-8', $headers);
-Assert::contains('X-Powered-By: Nette Framework 3', $headers);
+$headers = $container->getByType(Nette\Http\Response::class)->getHeaders();
+Assert::same([
+	'X-Powered-By' => ['Nette Framework 3'],
+	'Content-Type' => ['text/html; charset=utf-8'],
+	'X-Frame-Options' => ['SAMEORIGIN'],
+	'Set-Cookie' => ['nette-samesite=1; path=/; HttpOnly; SameSite=Strict'],
+], $headers);

--- a/tests/Http.DI/HttpExtension.featurePolicy.phpt
+++ b/tests/Http.DI/HttpExtension.featurePolicy.phpt
@@ -13,10 +13,6 @@ use Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
 
-if (PHP_SAPI === 'cli') {
-	Tester\Environment::skip('Headers are not testable in CLI mode');
-}
-
 
 $compiler = new DI\Compiler;
 $compiler->addExtension('http', new HttpExtension);
@@ -37,16 +33,6 @@ eval($compiler->addConfig($config)->compile());
 $container = new Container;
 $container->initialize();
 
-$headers = headers_list();
-var_dump($headers);
+$headers = $container->getByType(Nette\Http\Response::class)->getHeaders();
 
-Assert::contains("Feature-Policy: unsized-media 'none'; geolocation 'self' https://example.com; camera *;", $headers);
-
-
-echo ' '; @ob_flush(); flush();
-
-Assert::true(headers_sent());
-
-Assert::exception(function () use ($container) {
-	$container->initialize();
-}, Nette\InvalidStateException::class, 'Cannot send header after %a%');
+Assert::same(["unsized-media 'none'; geolocation 'self' https://example.com; camera *;"], $headers['Feature-Policy']);

--- a/tests/Http.DI/HttpExtension.sameSiteProtection.phpt
+++ b/tests/Http.DI/HttpExtension.sameSiteProtection.phpt
@@ -9,10 +9,6 @@ use Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
 
-if (PHP_SAPI === 'cli') {
-	Tester\Environment::skip('Headers are not testable in CLI mode');
-}
-
 
 $compiler = new DI\Compiler;
 $compiler->addExtension('http', new HttpExtension);
@@ -23,10 +19,8 @@ eval($compiler->compile());
 $container = new Container;
 $container->initialize();
 
-$headers = headers_list();
-Assert::contains(
-	PHP_VERSION_ID >= 70300
-		? 'Set-Cookie: nette-samesite=1; path=/; HttpOnly; SameSite=Strict'
-		: 'Set-Cookie: nette-samesite=1; path=/; SameSite=Strict; HttpOnly',
-	$headers
+$headers = $container->getByType(Nette\Http\Response::class)->getHeaders();
+Assert::same(
+	['nette-samesite=1; path=/; HttpOnly; SameSite=Strict'],
+	$headers['Set-Cookie']
 );

--- a/tests/Http/Response.headers.phpt
+++ b/tests/Http/Response.headers.phpt
@@ -12,10 +12,6 @@ use Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
 
-if (PHP_SAPI === 'cli') {
-	Tester\Environment::skip('Headers are not available in CLI');
-}
-
 
 $response = new Http\Response;
 

--- a/tests/Http/Response.redirect.phpt
+++ b/tests/Http/Response.redirect.phpt
@@ -15,22 +15,13 @@ require __DIR__ . '/../bootstrap.php';
 
 $response = new Http\Response;
 
-ob_start();
 $response->redirect('http://nette.org/&');
-Assert::same("<h1>Redirect</h1>\n\n<p><a href=\"http://nette.org/&amp;\">Please click here to continue</a>.</p>", ob_get_clean());
+Assert::same("<h1>Redirect</h1>\n\n<p><a href=\"http://nette.org/&amp;\">Please click here to continue</a>.</p>", $response->getBody());
 
-if (PHP_SAPI !== 'cli') {
-	Assert::contains('Location: http://nette.org/&', headers_list());
-}
+Assert::same(['Location' => ['http://nette.org/&']], $response->getHeaders());
 
 
-ob_start();
 $response->redirect(' javascript:alert(1)');
-Assert::same('', ob_get_clean());
+Assert::same('', $response->getBody());
 
-if (PHP_SAPI !== 'cli') {
-	Assert::contains('Location:  javascript:alert(1)', headers_list());
-}
-
-
-$response->setCode(200);
+Assert::same(['Location' => ['javascript:alert(1)']], $response->getHeaders());

--- a/tests/Http/Response.setCookie.phpt
+++ b/tests/Http/Response.setCookie.phpt
@@ -12,36 +12,23 @@ use Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
 
-if (PHP_SAPI === 'cli') {
-	Tester\Environment::skip('Cookies are not available in CLI');
-}
 
 
-$old = headers_list();
 $response = new Http\Response;
 
-
 $response->setCookie('test', 'value', 0);
-$headers = array_values(array_diff(headers_list(), $old, ['Set-Cookie:']));
 Assert::same([
-	'Set-Cookie: test=value; path=/; HttpOnly',
-], $headers);
+	'Set-Cookie' => ['test=value; path=/; HttpOnly'],
+], $response->getHeaders());
 
 
 $response->setCookie('test', 'newvalue', 0);
-$headers = array_values(array_diff(headers_list(), $old, ['Set-Cookie:']));
 Assert::same([
-	'Set-Cookie: test=value; path=/; HttpOnly',
-	'Set-Cookie: test=newvalue; path=/; HttpOnly',
-], $headers);
+	'Set-Cookie' => ['test=value; path=/; HttpOnly', 'test=newvalue; path=/; HttpOnly'],
+], $response->getHeaders());
 
 
 $response->setCookie('test', 'newvalue', 0, null, null, null, null, 'Lax');
-$headers = array_values(array_diff(headers_list(), $old, ['Set-Cookie:']));
 Assert::same([
-	'Set-Cookie: test=value; path=/; HttpOnly',
-	'Set-Cookie: test=newvalue; path=/; HttpOnly',
-	PHP_VERSION_ID >= 70300
-		? 'Set-Cookie: test=newvalue; path=/; HttpOnly; SameSite=Lax'
-		: 'Set-Cookie: test=newvalue; path=/; SameSite=Lax; HttpOnly',
-], $headers);
+	'Set-Cookie' => ['test=value; path=/; HttpOnly', 'test=newvalue; path=/; HttpOnly', 'test=newvalue; path=/; HttpOnly; SameSite=Lax'],
+], $response->getHeaders());

--- a/tests/Http/Response.toString.phpt
+++ b/tests/Http/Response.toString.phpt
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$response = new Http\Response;
+$response->setProtocolVersion('3.0');
+$response->setCode(123, 'My Reason');
+$response->setHeader('X-A', 'a');
+$response->addHeader('X-A', 'b');
+$response->setBody('Hello');
+
+Assert::same(
+	"HTTP/3.0 123 My Reason\r\nX-A: a\r\nX-A: b\r\n\r\nHello",
+	(string) $response
+);

--- a/tests/Http/ResponseEmitter.phpt
+++ b/tests/Http/ResponseEmitter.phpt
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Test: Nette\Http\ResponseEmitter.
+ * @httpCode 123
+ */
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function () {
+	$response = new Http\Response;
+	$response->setCode(123, 'my reason');
+	$response->setHeader('A', 'b');
+	$response->addHeader('A', 'c');
+	$response->setBody('hello');
+
+	$emitter = new Http\ResponseEmitter;
+
+	ob_start();
+	$emitter->send($response);
+	Assert::same('hello', ob_get_clean());
+
+
+	if (PHP_SAPI !== 'cli') {
+		Assert::same(['A: b', 'A: c'], headers_list());
+	}
+});
+
+
+test(function () {
+	$response = new Http\Response;
+	$response->setCode(123, 'my reason');
+	$response->setHeader('B', 'b');
+	$response->setBody(function () {
+		echo 'nette';
+	});
+
+	$emitter = new Http\ResponseEmitter;
+
+	ob_start();
+	$emitter->send($response);
+	Assert::same('nette', ob_get_clean());
+
+
+	if (PHP_SAPI !== 'cli') {
+		Assert::same(['B: b'], headers_list());
+	}
+});

--- a/tests/Http/ResponseFactory.fromGlobals.phpt
+++ b/tests/Http/ResponseFactory.fromGlobals.phpt
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Test: Nette\Http\ResponseFactory::fromGlobals()
+ */
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$_SERVER['SERVER_PROTOCOL'] = 'HTTP/3.0';
+http_response_code(123);
+header('X-A: b');
+
+$factory = new Http\ResponseFactory;
+$response = $factory->fromGlobals();
+
+Assert::same(123, $response->getCode());
+Assert::same('3.0', $response->getProtocolVersion());
+
+if (PHP_SAPI === 'cli') {
+	Assert::same([], $response->getHeaders());
+} else {
+	Assert::same(['b'], $response->getHeaders()['X-A']);
+}
+
+Assert::same('', $response->getBody());
+
+http_response_code(200);

--- a/tests/Http/ResponseFactory.fromString.phpt
+++ b/tests/Http/ResponseFactory.fromString.phpt
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$factory = new Http\ResponseFactory;
+$response = $factory->fromString("HTTP/3.0 123 My Reason\r\nX-A: a\r\nX-A: b\r\n\r\nHello");
+
+Assert::same(123, $response->getCode());
+Assert::same('3.0', $response->getProtocolVersion());
+Assert::same('My Reason', $response->getReasonPhrase());
+
+Assert::same(['X-A' => ['a', 'b']], $response->getHeaders());
+
+Assert::same('Hello', $response->getBody());

--- a/tests/Http/ResponseFactory.fromUrl.phpt
+++ b/tests/Http/ResponseFactory.fromUrl.phpt
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$factory = new Http\ResponseFactory;
+$response = $factory->fromUrl('http://nette.org');
+
+Assert::same(200, $response->getCode());
+Assert::same('1.1', $response->getProtocolVersion());
+Assert::same('OK', $response->getReasonPhrase());
+Assert::same(['SAMEORIGIN'], $response->getHeaders()['X-Frame-Options']);
+Assert::contains('Nette Foundation', $response->getBody());

--- a/tests/Http/Session.cache.phpt
+++ b/tests/Http/Session.cache.phpt
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function () {
+	$factory = new Nette\Http\RequestFactory;
+	$response = new Nette\Http\Response;
+	$session = new Nette\Http\Session($factory->fromGlobals(), $response);
+
+	$session->setOptions([
+		'cache_limiter' => 'public',
+		'cache_expire' => '180',
+	]);
+	$session->start();
+
+	Assert::same(
+		[
+			'Set-Cookie' => ['PHPSESSID=' . $session->getId() . '; path=/; HttpOnly'],
+			'Expires' => [Nette\Http\Helpers::formatDate(time() + 180 * 60)],
+			'Cache-Control' => ['public, max-age=10800'],
+			'Last-Modified' => [Nette\Http\Helpers::formatDate(getlastmod())],
+		],
+		$response->getHeaders()
+	);
+
+	$session->close();
+});
+
+
+test(function () {
+	$factory = new Nette\Http\RequestFactory;
+	$response = new Nette\Http\Response;
+	$session = new Nette\Http\Session($factory->fromGlobals(), $response);
+
+	$session->setOptions([
+		'cache_limiter' => 'private_no_expire',
+		'cache_expire' => '180',
+	]);
+	$session->start();
+
+	Assert::same(
+		[
+			'Set-Cookie' => ['PHPSESSID=' . $session->getId() . '; path=/; HttpOnly'],
+			'Cache-Control' => ['private, max-age=10800'],
+			'Last-Modified' => [Nette\Http\Helpers::formatDate(getlastmod())],
+		],
+		$response->getHeaders()
+	);
+
+	$session->close();
+});
+
+
+test(function () {
+	$factory = new Nette\Http\RequestFactory;
+	$response = new Nette\Http\Response;
+	$session = new Nette\Http\Session($factory->fromGlobals(), $response);
+
+	$session->setOptions([
+		'cache_limiter' => 'private',
+		'cache_expire' => '180',
+	]);
+	$session->start();
+
+	Assert::same(
+		[
+			'Set-Cookie' => ['PHPSESSID=' . $session->getId() . '; path=/; HttpOnly'],
+			'Expires' => ['Mon, 23 Jan 1978 10:00:00 GMT'],
+			'Cache-Control' => ['private, max-age=10800'],
+			'Last-Modified' => [Nette\Http\Helpers::formatDate(getlastmod())],
+		],
+		$response->getHeaders()
+	);
+
+	$session->close();
+});
+
+
+test(function () {
+	$factory = new Nette\Http\RequestFactory;
+	$response = new Nette\Http\Response;
+	$session = new Nette\Http\Session($factory->fromGlobals(), $response);
+
+	$session->setOptions([
+		'cache_limiter' => 'nocache',
+	]);
+	$session->start();
+
+	Assert::same(
+		[
+			'Set-Cookie' => ['PHPSESSID=' . $session->getId() . '; path=/; HttpOnly'],
+			'Expires' => ['Mon, 23 Jan 1978 10:00:00 GMT'],
+			'Cache-Control' => ['no-store, no-cache, must-revalidate'],
+			'Pragma' => ['no-cache'],
+		],
+		$response->getHeaders()
+	);
+
+	$session->close();
+});

--- a/tests/Http/Session.id.phpt
+++ b/tests/Http/Session.id.phpt
@@ -20,7 +20,8 @@ $_COOKIE[$sessionName] = $leet = md5('1337');
 $cookies = [$sessionName => $sessionId = md5('1')];
 file_put_contents(getTempDir() . '/sess_' . $sessionId, sprintf('__NF|a:2:{s:4:"Time";i:%s;s:4:"DATA";a:1:{s:4:"temp";a:1:{s:5:"value";s:3:"yes";}}}', time() - 1000));
 
-$session = new Session(new Http\Request(new Http\UrlScript('http://nette.org'), [], [], $cookies), new Http\Response);
+$response = new Http\Response;
+$session = new Session(new Http\Request(new Http\UrlScript('http://nette.org'), [], [], $cookies), $response);
 
 $session->start();
 Assert::same($sessionId, $session->getId());
@@ -32,3 +33,5 @@ $session->close();
 // session was not regenerated
 Assert::true(file_exists(getTempDir() . '/sess_' . $sessionId));
 Assert::count(1, glob(getTempDir() . '/sess_*'));
+
+Assert::same(['PHPSESSID=' . $sessionId . '; path=/; HttpOnly'], $response->getHeaders()['Set-Cookie']);

--- a/tests/Http/Session.regenerateId().phpt
+++ b/tests/Http/Session.regenerateId().phpt
@@ -13,7 +13,8 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-$session = new Session(new Nette\Http\Request(new Nette\Http\UrlScript), new Nette\Http\Response);
+$response = new Nette\Http\Response;
+$session = new Session(new Nette\Http\Request(new Nette\Http\UrlScript), $response);
 
 $path = rtrim(ini_get('session.save_path'), '/\\') . '/sess_';
 
@@ -30,3 +31,5 @@ Assert::true(is_file($path . $newId));
 
 $ref = 20;
 Assert::same(20, $_SESSION['var']);
+
+Assert::same(['PHPSESSID=' . $newId . '; path=/; HttpOnly'], $response->getHeaders()['Set-Cookie']);

--- a/tests/Http/Session.sameSite.phpt
+++ b/tests/Http/Session.sameSite.phpt
@@ -7,10 +7,6 @@ use Tester\Assert;
 
 require __DIR__ . '/../bootstrap.php';
 
-if (PHP_SAPI === 'cli') {
-	Tester\Environment::skip('Cookies are not available in CLI');
-}
-
 
 $factory = new Nette\Http\RequestFactory;
 $response = new Nette\Http\Response;
@@ -22,9 +18,7 @@ $session->setOptions([
 
 $session->start();
 
-Assert::contains(
-	PHP_VERSION_ID >= 70300
-		? 'Set-Cookie: PHPSESSID=' . $session->getId() . '; path=/; HttpOnly; SameSite=Lax'
-		: 'Set-Cookie: PHPSESSID=' . $session->getId() . '; path=/; SameSite=Lax; HttpOnly',
-	headers_list()
+Assert::same(
+	['PHPSESSID=' . $session->getId() . '; path=/; HttpOnly; SameSite=Lax'],
+	$response->getHeaders()['Set-Cookie']
 );

--- a/tests/Http/SessionSection.basic.phpt
+++ b/tests/Http/SessionSection.basic.phpt
@@ -39,4 +39,4 @@ unset($namespace['a'], $namespace->p, $namespace->o, $namespace->undef);
 
 
 
-Assert::same('', http_build_query($namespace->getIterator()));
+Assert::same('', http_build_query(iterator_to_array($namespace->getIterator())));

--- a/tests/Http/SessionSection.remove.phpt
+++ b/tests/Http/SessionSection.remove.phpt
@@ -20,10 +20,12 @@ $namespace->a = 'apple';
 $namespace->p = 'papaya';
 $namespace['c'] = 'cherry';
 
+dump($namespace);
+
 $namespace = $session->getSection('three');
-Assert::same('a=apple&p=papaya&c=cherry', http_build_query($namespace->getIterator()));
+Assert::same('a=apple&p=papaya&c=cherry', http_build_query(iterator_to_array($namespace->getIterator())));
 
 
 // removing
 $namespace->remove();
-Assert::same('', http_build_query($namespace->getIterator()));
+Assert::same('', http_build_query(iterator_to_array($namespace->getIterator())));

--- a/tests/Http/SessionSection.removeExpiration().phpt
+++ b/tests/Http/SessionSection.removeExpiration().phpt
@@ -26,4 +26,4 @@ sleep(3);
 $session->start();
 
 $section = $session->getSection('expireRemove');
-Assert::same('a=apple&b=banana', http_build_query($section->getIterator()));
+Assert::same('a=apple&b=banana', http_build_query(iterator_to_array($section->getIterator())));

--- a/tests/Http/SessionSection.setExpiration().phpt
+++ b/tests/Http/SessionSection.setExpiration().phpt
@@ -29,7 +29,7 @@ test(function () use ($session) { // try to expire whole namespace
 	$session->start();
 
 	$namespace = $session->getSection('expire');
-	Assert::same('', http_build_query($namespace->getIterator()));
+	Assert::same('', http_build_query(iterator_to_array($namespace->getIterator())));
 });
 
 
@@ -44,7 +44,7 @@ test(function () use ($session) { // try to expire only 1 of the keys
 	$session->start();
 
 	$namespace = $session->getSection('expireSingle');
-	Assert::same('p=plum', http_build_query($namespace->getIterator()));
+	Assert::same('p=plum', http_build_query(iterator_to_array($namespace->getIterator())));
 });
 
 

--- a/tests/Http/SessionSection.undefined.phpt
+++ b/tests/Http/SessionSection.undefined.phpt
@@ -18,4 +18,4 @@ $session = new Session(new Nette\Http\Request(new Nette\Http\UrlScript), new Net
 $namespace = $session->getSection('one');
 Assert::false(isset($namespace->undefined));
 Assert::null($namespace->undefined); // Getting value of non-existent key
-Assert::same('', http_build_query($namespace->getIterator()));
+Assert::same('', http_build_query(iterator_to_array($namespace->getIterator())));


### PR DESCRIPTION
- bug fix
- BC break? yes

I think in case of configure option `cookieSecure === true` the control cookie `nette-samesite` should be secured too.

Currently behavior is like:

![image](https://user-images.githubusercontent.com/4738758/69006770-4f345300-0934-11ea-832d-773901e2cd4b.png)

You can see the cookie `nette-samesite` is not secured and some tests report security issue.

My changes make report more better:

![image](https://user-images.githubusercontent.com/4738758/69006779-74c15c80-0934-11ea-8ecf-f22acdffe1b0.png)

But this security policy must be active only in case of `https`.

Thanks.