### PR TITLE
FileUpload::getSanitizedName: Remove redundant minus before dot.

### DIFF
--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -75,7 +75,7 @@ final class FileUpload
 	 */
 	public function getSanitizedName(): string
 	{
-		return trim(Nette\Utils\Strings::webalize($this->name, '.', false), '.-');
+		return trim(str_replace('-.', '.', Nette\Utils\Strings::webalize($this->name, '.', false)), '.-');
 	}
 
 

--- a/tests/Http/FileUpload.basic.phpt
+++ b/tests/Http/FileUpload.basic.phpt
@@ -53,6 +53,19 @@ test(function () {
 
 test(function () {
 	$upload = new FileUpload([
+		'name' => 'logo 2020+.pdf',
+		'type' => 'text/plain',
+		'tmp_name' => __DIR__ . '/files/logo.png',
+		'error' => 0,
+		'size' => 209,
+	]);
+
+	Assert::same('logo-2020.pdf', $upload->getSanitizedName());
+});
+
+
+test(function () {
+	$upload = new FileUpload([
 		'name' => '',
 		'type' => '',
 		'tmp_name' => '',


### PR DESCRIPTION
- new feature
- BC break? yes

In the case of the name `logo 2020+.pdf` old function return `logo-2020-.pdf`. I think more better behavior is simply `logo-2020.pdf` (without minus before dot separator).

Thanks.