### PR TITLE
Lets use dns instead of IP in proxy settings

### DIFF
--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -32,6 +32,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 	{
 		return Expect::structure([
 			'proxy' => Expect::anyOf(Expect::arrayOf('string'), Expect::string()->castTo('array'))->default([])->dynamic(),
+			'docker' => Expect::bool()->default(false),
 			'headers' => Expect::arrayOf('scalar|null')->default([
 				'X-Powered-By' => 'Nette Framework 3',
 				'Content-Type' => 'text/html; charset=utf-8',
@@ -49,10 +50,12 @@ class HttpExtension extends Nette\DI\CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 		$config = $this->config;
-
 		$builder->addDefinition($this->prefix('requestFactory'))
 			->setFactory(Nette\Http\RequestFactory::class)
-			->addSetup('setProxy', [$config->proxy]);
+			->addSetup('setDocker', [$config->docker])
+			->addSetup('setProxy', [$config->proxy])
+
+			;
 
 		$builder->addDefinition($this->prefix('request'))
 			->setFactory('@Nette\Http\RequestFactory::fromGlobals');

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -50,6 +50,8 @@ class RequestFactory
 	 */
 	public function setProxy($proxy)
 	{
+		if( is_array($proxy) )  foreach( $proxy as &$p ) $p = gethostbyname($p);
+        	else $proxy = gethostbyname($proxy);
 		$this->proxies = (array) $proxy;
 		return $this;
 	}

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -35,6 +35,9 @@ class RequestFactory
 	/** @var string[] */
 	private $proxies = [];
 
+	/** @var bool  */
+	private $docker = false;
+
 
 	/** @return static */
 	public function setBinary(bool $binary = true)
@@ -43,6 +46,15 @@ class RequestFactory
 		return $this;
 	}
 
+	/**
+     * @param bool $docker
+     * @return static
+     */
+	public function setDocker(bool $docker = false)
+	{
+	    $this->docker = $docker;
+	    return $this;
+  }
 
 	/**
 	 * @param  string|string[]  $proxy
@@ -50,8 +62,10 @@ class RequestFactory
 	 */
 	public function setProxy($proxy)
 	{
-		if( is_array($proxy) )  foreach( $proxy as &$p ) $p = gethostbyname($p);
-        	else $proxy = gethostbyname($proxy);
+		if($this->docker) {
+			if( is_array($proxy) ) foreach( $proxy as &$p ) $p = gethostbyname($p);
+			else $proxy = gethostbyname($proxy);
+		}
 		$this->proxies = (array) $proxy;
 		return $this;
 	}


### PR DESCRIPTION
Hi, when using nette on reverse proxy i found out when i want to use docker proxy i have to update 

http:
      proxy: [ip]

on every environment i use, instead of using docker created dns after service name in compose.  So this QoL edit let me use dns instead of IP

