### PR TITLE
ScriptUrl: Fix class extendability (issue #187)

### DIFF
--- a/src/Http/UrlScript.php
+++ b/src/Http/UrlScript.php
@@ -54,7 +54,8 @@ class UrlScript extends UrlImmutable
 	{
 		$dolly = clone $this;
 		$dolly->scriptPath = $scriptPath;
-		return call_user_func([$dolly, 'parent::withPath'], $path);
+		$parent = \Closure::fromCallable([UrlImmutable::class, 'withPath'])->bindTo($dolly);
+		return $parent($path);
 	}
 
 


### PR DESCRIPTION
- bug fix: #187 
- BC break? no

`UrlScript` is not work correctly when is extended. The [method `withPath()`](https://github.com/nette/http/blob/v3.0.5/src/Http/UrlScript.php#L53-L58) is calling themself recursive in infinite loop and crash with error:
```
Maximum function nesting level of '256' reached, aborting!
```

The reason is the callback `parent::withPath` in `call_user_func()` function is always called in top of descendants hierarchy context (see more at issue #187).

PR is changing relative reference to parent class to absolute. Here is no able to use only `parent` because method is called in another instance than `$this` (cloned one).

Tests:
- All passed.
- No new one necessary

Resolve #187