### PR TITLE
Allow users to change cookieNameStrict in configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macOS-latest]
-                php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php: ['7.2', '7.3', '7.4', '8.0']
 #                sapi: ['php', 'php-cgi']
 
             fail-fast: false
@@ -38,7 +38,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.1
+                  php-version: 7.2
                   coverage: none
                   extensions: fileinfo, intl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-    - 7.1
     - 7.2
     - 7.3
     - 7.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
     # Install PHP
     - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
     - IF %PHP%==1 cd c:\php
-    - IF %PHP%==1 curl https://windows.php.net/downloads/releases/archives/php-7.1.0-Win32-VC14-x64.zip --output php.zip
+    - IF %PHP%==1 curl https://windows.php.net/downloads/releases/archives/php-7.2.28-Win32-VC15-x64.zip --output php.zip
     - IF %PHP%==1 7z x php.zip >nul
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
     - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.0-dev"
+			"dev-master": "3.1-dev"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1 <8.1",
+		"php": ">=7.2 <8.1",
 		"nette/utils": "^3.1"
 	},
 	"require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Installation:
 composer require nette/http
 ```
 
-It requires PHP version 7.1 and supports PHP up to 8.0.
+It requires PHP version 7.2 and supports PHP up to 8.0.
 
 
 HTTP Request

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -41,7 +41,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			'cspReportOnly' => Expect::arrayOf('array|scalar|null'), // Content-Security-Policy-Report-Only
 			'featurePolicy' => Expect::arrayOf('array|scalar|null'), // Feature-Policy
 			'cookieSecure' => Expect::anyOf(null, true, false, 'auto')->default('auto'), // true|false|auto  Whether the cookie is available only through HTTPS
-            'cookieNameStrict' => Expect::anyOf(Expect::string(), Expect::bool(), null)->default('nette-samesite'),
+                        'cookieNameStrict' => Expect::anyOf(Expect::string(), Expect::bool(), null)->default('nette-samesite'),
 		]);
 	}
 

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -41,7 +41,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			'cspReportOnly' => Expect::arrayOf('array|scalar|null'), // Content-Security-Policy-Report-Only
 			'featurePolicy' => Expect::arrayOf('array|scalar|null'), // Feature-Policy
 			'cookieSecure' => Expect::anyOf(null, true, false, 'auto')->default('auto'), // true|false|auto  Whether the cookie is available only through HTTPS
-                        'cookieNameStrict' => Expect::anyOf(Expect::string(), Expect::bool(), null)->default('nette-samesite'),
+			'cookieNameStrict' => Expect::anyOf(Expect::string(), Expect::bool(), null)->default('nette-samesite'),
 		]);
 	}
 
@@ -123,7 +123,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 
 		$this->initialization->addBody(
 			'Nette\Http\Helpers::initCookie($this->getService(?), $response, ?);',
-			[$this->prefix('request') , $config->cookieNameStrict]
+			[$this->prefix('request'), $config->cookieNameStrict]
 		);
 	}
 

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -41,6 +41,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			'cspReportOnly' => Expect::arrayOf('array|scalar|null'), // Content-Security-Policy-Report-Only
 			'featurePolicy' => Expect::arrayOf('array|scalar|null'), // Feature-Policy
 			'cookieSecure' => Expect::anyOf(null, true, false, 'auto')->default('auto'), // true|false|auto  Whether the cookie is available only through HTTPS
+            'cookieNameStrict' => Expect::anyOf(Expect::string(), Expect::bool(), null)->default('nette-samesite'),
 		]);
 	}
 
@@ -121,8 +122,8 @@ class HttpExtension extends Nette\DI\CompilerExtension
 		}
 
 		$this->initialization->addBody(
-			'Nette\Http\Helpers::initCookie($this->getService(?), $response);',
-			[$this->prefix('request')]
+			'Nette\Http\Helpers::initCookie($this->getService(?), $response, ?);',
+			[$this->prefix('request') , $config->cookieNameStrict]
 		);
 	}
 

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -56,10 +56,6 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			->addSetup('setProxy', [$config->proxy]);
 
 		$builder->addDefinition($this->prefix('request'))
-			->setFactory(Nette\Http\Request::class)
-			->addSetup('set_cookieNameStrict', [$config->cookieNameStrict]);
-
-		$builder->addDefinition($this->prefix('request'))
 			->setFactory('@Nette\Http\RequestFactory::fromGlobals');
 
 		$response = $builder->addDefinition($this->prefix('response'))

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -56,11 +56,8 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			->addSetup('setProxy', [$config->proxy]);
 
 		$builder->addDefinition($this->prefix('request'))
-			->setFactory('@Nette\Http\RequestFactory::fromGlobals');
-
-		$builder->addDefinition($this->prefix('request'))
-			->setFactory(Nette\Http\Request::class)
-			->addSetup('set_cookieNameStrict', [$config->cookieNameStrict]);
+			->setFactory('@Nette\Http\RequestFactory::fromGlobals')
+			->addSetup('set_cookieNameStrict', [$config->cookieNameStrict]);;
 
 		$response = $builder->addDefinition($this->prefix('response'))
 			->setFactory(Nette\Http\Response::class);

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -57,7 +57,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 
 		$builder->addDefinition($this->prefix('request'))
 			->setFactory('@Nette\Http\RequestFactory::fromGlobals')
-			->addSetup('set_cookieNameStrict', [$config->cookieNameStrict]);;
+			->addSetup('setCookieNameStrict', [$config->cookieNameStrict]);;
 
 		$response = $builder->addDefinition($this->prefix('response'))
 			->setFactory(Nette\Http\Response::class);

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -56,6 +56,10 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			->addSetup('setProxy', [$config->proxy]);
 
 		$builder->addDefinition($this->prefix('request'))
+			->setFactory(Nette\Http\Request::class)
+			->addSetup('set_cookieNameStrict', [$config->cookieNameStrict]);
+
+		$builder->addDefinition($this->prefix('request'))
 			->setFactory('@Nette\Http\RequestFactory::fromGlobals');
 
 		$response = $builder->addDefinition($this->prefix('response'))

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -57,7 +57,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 
 		$builder->addDefinition($this->prefix('request'))
 			->setFactory('@Nette\Http\RequestFactory::fromGlobals')
-			->addSetup('setCookieNameStrict', [$config->cookieNameStrict]);;
+			->addSetup('setCookieNameStrict', [$config->cookieNameStrict]);
 
 		$response = $builder->addDefinition($this->prefix('response'))
 			->setFactory(Nette\Http\Response::class);

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -58,6 +58,10 @@ class HttpExtension extends Nette\DI\CompilerExtension
 		$builder->addDefinition($this->prefix('request'))
 			->setFactory('@Nette\Http\RequestFactory::fromGlobals');
 
+		$builder->addDefinition($this->prefix('request'))
+			->setFactory(Nette\Http\Request::class)
+			->addSetup('set_cookieNameStrict', [$config->cookieNameStrict]);
+
 		$response = $builder->addDefinition($this->prefix('response'))
 			->setFactory(Nette\Http\Response::class);
 

--- a/src/Bridges/HttpDI/HttpExtension.php
+++ b/src/Bridges/HttpDI/HttpExtension.php
@@ -40,7 +40,7 @@ class HttpExtension extends Nette\DI\CompilerExtension
 			'csp' => Expect::arrayOf('array|scalar|null'), // Content-Security-Policy
 			'cspReportOnly' => Expect::arrayOf('array|scalar|null'), // Content-Security-Policy-Report-Only
 			'featurePolicy' => Expect::arrayOf('array|scalar|null'), // Feature-Policy
-			'cookieSecure' => Expect::anyOf(null, true, false, 'auto'), // true|false|auto  Whether the cookie is available only through HTTPS
+			'cookieSecure' => Expect::anyOf(null, true, false, 'auto')->default('auto'), // true|false|auto  Whether the cookie is available only through HTTPS
 		]);
 	}
 

--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -62,9 +62,7 @@ final class FileUpload
 
 
 	/**
-	 * Returns the original file name as submitted by the browser. Do not trust the value returned by this method.
-	 * A client could send a malicious filename with the intention to corrupt or hack your application.
-	 * Alias for getUntrustedName()
+	 * @deprecated use getUntrustedName()
 	 */
 	public function getName(): string
 	{

--- a/src/Http/Helpers.php
+++ b/src/Http/Helpers.php
@@ -52,10 +52,10 @@ final class Helpers
 	}
 
 
-	public static function initCookie(IRequest $request, IResponse $response)
+	public static function initCookie(IRequest $request, IResponse $response, $cookieName = self::STRICT_COOKIE_NAME)
 	{
-		if (!$request->getCookie(self::STRICT_COOKIE_NAME)) {
-			$response->setCookie(self::STRICT_COOKIE_NAME, '1', 0, '/', null, null, true, 'Strict');
+		if (!$request->getCookie($cookieName)) {
+			$response->setCookie($cookieName, '1', 0, '/', null, null, true, 'Strict');
 		}
 	}
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -142,11 +142,15 @@ class Request implements IRequest
 
 	/**
 	 * Returns uploaded file.
-	 * @return FileUpload|array|null
+	 * @param  string|string[]  $key
+	 * @return ?FileUpload
 	 */
-	public function getFile(string $key)
+	public function getFile($key)
 	{
-		return $this->files[$key] ?? null;
+		$res = Nette\Utils\Arrays::get($this->files, $key, null);
+		return $res instanceof FileUpload
+			? $res
+			: null;
 	}
 
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -87,11 +87,12 @@ class Request implements IRequest
 		$this->cookieNameStrict = Helpers::STRICT_COOKIE_NAME;
 	}
 
-	 /**
+	/**
 	 * Setter for cookieNameStrict
 	 * @param string $name
 	 */
-	public function setCookieNameStrict(string $name) {
+	public function setCookieNameStrict(string $name)
+	{
 		$this->cookieNameStrict = $name;
 	}
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -60,6 +60,9 @@ class Request implements IRequest
 	/** @var callable|null */
 	private $rawBodyCallback;
 
+	/** @var string */
+	private $cookieNameStrict;
+
 
 	public function __construct(
 		UrlScript $url,
@@ -81,8 +84,16 @@ class Request implements IRequest
 		$this->remoteAddress = $remoteAddress;
 		$this->remoteHost = $remoteHost;
 		$this->rawBodyCallback = $rawBodyCallback;
+		$this->cookieNameStrict = Helpers::STRICT_COOKIE_NAME;
 	}
 
+	 /**
+	 * Setter for cookieNameStrict
+	 * @param string $name
+	 */
+	public function set_cookieNameStrict(string $name) {
+		$this->cookieNameStrict = $name;
+	}
 
 	/**
 	 * Returns a clone with a different URL.
@@ -253,7 +264,7 @@ class Request implements IRequest
 	 */
 	public function isSameSite(): bool
 	{
-		return isset($this->cookies[Helpers::STRICT_COOKIE_NAME]);
+		return isset($this->cookies[$this->cookieNameStrict]);
 	}
 
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -91,7 +91,7 @@ class Request implements IRequest
 	 * Setter for cookieNameStrict
 	 * @param string $name
 	 */
-	public function set_cookieNameStrict(string $name) {
+	public function setCookieNameStrict(string $name) {
 		$this->cookieNameStrict = $name;
 	}
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -87,6 +87,7 @@ class Request implements IRequest
 		$this->cookieNameStrict = Helpers::STRICT_COOKIE_NAME;
 	}
 
+
 	/**
 	 * Setter for cookieNameStrict
 	 * @param string $name
@@ -95,6 +96,7 @@ class Request implements IRequest
 	{
 		$this->cookieNameStrict = $name;
 	}
+
 
 	/**
 	 * Returns a clone with a different URL.

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -163,8 +163,11 @@ class RequestFactory
 						$list[$key][$k] = $v;
 						$list[] = &$list[$key][$k];
 
-					} else {
+					} elseif (is_string($v)) {
 						$list[$key][$k] = (string) preg_replace('#[^' . self::CHARS . ']+#u', '', $v);
+
+					} else {
+						throw new Nette\InvalidStateException(sprintf('Invalid value in $_POST/$_COOKIE in key %s, expected string, %s given.', "'$k'", gettype($v)));
 					}
 				}
 			}

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -466,6 +466,7 @@ class Session
 	/** @deprecated */
 	public function getCookieParameters(): array
 	{
+		trigger_error(__METHOD__ . '() is deprecated.', E_USER_DEPRECATED);
 		return session_get_cookie_params();
 	}
 

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -16,13 +16,13 @@ use Nette;
  * Mutable representation of a URL.
  *
  * <pre>
- * scheme  user  password  host  port  basePath   relativeUrl
- *   |      |      |        |      |    |             |
- * /--\   /--\ /------\ /-------\ /--\/--\/----------------------------\
+ * scheme  user  password  host  port      path        query    fragment
+ *   |      |      |        |      |        |            |         |
+ * /--\   /--\ /------\ /-------\ /--\/------------\ /--------\ /------\
  * http://john:x0y17575@nette.org:8042/en/manual.php?name=param#fragment  <-- absoluteUrl
- *        \__________________________/\____________/^\________/^\______/
- *                     |                     |           |         |
- *                 authority               path        query    fragment
+ * \______\__________________________/
+ *     |               |
+ *  hostUrl        authority
  * </pre>
  *
  * @property   string $scheme
@@ -316,6 +316,7 @@ class Url implements \JsonSerializable
 	}
 
 
+	/** @deprecated */
 	public function getBasePath(): string
 	{
 		$pos = strrpos($this->path, '/');
@@ -323,12 +324,14 @@ class Url implements \JsonSerializable
 	}
 
 
+	/** @deprecated */
 	public function getBaseUrl(): string
 	{
 		return $this->getHostUrl() . $this->getBasePath();
 	}
 
 
+	/** @deprecated */
 	public function getRelativeUrl(): string
 	{
 		return substr($this->getAbsoluteUrl(), strlen($this->getBaseUrl()));
@@ -360,6 +363,7 @@ class Url implements \JsonSerializable
 	/**
 	 * Transforms URL to canonical form.
 	 * @return static
+	 * @deprecated
 	 */
 	public function canonicalize()
 	{

--- a/src/Http/UrlScript.php
+++ b/src/Http/UrlScript.php
@@ -54,7 +54,8 @@ class UrlScript extends UrlImmutable
 	{
 		$dolly = clone $this;
 		$dolly->scriptPath = $scriptPath;
-		return call_user_func([$dolly, 'parent::withPath'], $path);
+		$parent = \Closure::fromCallable([UrlImmutable::class, 'withPath'])->bindTo($dolly);
+		return $parent($path);
 	}
 
 

--- a/tests/Http.DI/HttpExtension.sameSiteProtectionCustom.phpt
+++ b/tests/Http.DI/HttpExtension.sameSiteProtectionCustom.phpt
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Bridges\HttpDI\HttpExtension;
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+if (PHP_SAPI === 'cli') {
+	Tester\Environment::skip('Headers are not testable in CLI mode');
+}
+
+
+$compiler = new DI\Compiler;
+$compiler->addExtension('http', new HttpExtension);
+$loader = new DI\Config\Loader;
+$config = $loader->load(Tester\FileMock::create(<<<'EOD'
+http:
+	cookieNameStrict: test-samesite
+EOD
+, 'neon'));
+
+// protection is enabled by default
+eval($compiler->addConfig($config)->compile());
+
+$container = new Container;
+$container->initialize();
+
+$headers = headers_list();
+Assert::contains(
+	PHP_VERSION_ID >= 70300
+		? 'Set-Cookie: test-samesite=1; path=/; HttpOnly; SameSite=Strict'
+		: 'Set-Cookie: test-samesite=1; path=/; SameSite=Strict; HttpOnly',
+	$headers
+);

--- a/tests/Http/Request.files.phpt
+++ b/tests/Http/Request.files.phpt
@@ -111,4 +111,4 @@ Assert::false(isset($request->files['file0']));
 Assert::true(isset($request->files['file1']));
 
 Assert::null($request->getFile('empty1'));
-Assert::same([null], $request->getFile('empty2'));
+Assert::null($request->getFile('empty2'));

--- a/tests/Http/Request.invalidType.phpt
+++ b/tests/Http/Request.invalidType.phpt
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Test: Nette\Http\Request invalid data.
+ */
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('invalid POST', function () {
+	$_POST = [
+		'int' => 1,
+	];
+
+	Assert::exception(function () {
+		(new Http\RequestFactory)->fromGlobals();
+	}, Nette\InvalidStateException::class, 'Invalid value in $_POST/$_COOKIE in key \'int\', expected string, integer given.');
+});
+
+
+test('invalid COOKIE', function () {
+	$_POST = [];
+	$_COOKIE = ['x' => [1]];
+
+	Assert::exception(function () {
+		(new Http\RequestFactory)->fromGlobals();
+	}, Nette\InvalidStateException::class, 'Invalid value in $_POST/$_COOKIE in key \'0\', expected string, integer given.');
+});


### PR DESCRIPTION
- new feature? 
Security enhancement by leting users choose to change nette-samesite cookie name  

#182 

Allow users to change cookie name is a security enhancement because sometimes there is no need to say site users what technology site is using.


http:
    cookieNameStrict: fancyname-samesite



- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Allow users to change cookie name is a security enhancement because sometimes there is no need to say site users what technology site is using.
-->
