### PR TITLE
Request: In case of CLI method should be CLI too.

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -77,7 +77,7 @@ class Request implements IRequest
 		$this->files = (array) $files;
 		$this->cookies = (array) $cookies;
 		$this->headers = array_change_key_case((array) $headers, CASE_LOWER);
-		$this->method = $method ?: 'GET';
+		$this->method = $method ?: (PHP_SAPI === 'cli' ? 'CLI' : 'GET');
 		$this->remoteAddress = $remoteAddress;
 		$this->remoteHost = $remoteHost;
 		$this->rawBodyCallback = $rawBodyCallback;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -311,7 +311,7 @@ final class Response implements IResponse
 			ob_get_length() &&
 			!array_filter(ob_get_status(true), function (array $i): bool { return !$i['chunk_size']; })
 		) {
-			trigger_error('Possible problem: you are sending a HTTP header while already having some data in output buffer. Try Tracy\OutputDebugger or start session earlier.');
+			trigger_error('Possible problem: you are sending a HTTP header while already having some data in output buffer. Try Tracy\OutputDebugger or send cookies/start session earlier.');
 		}
 	}
 }


### PR DESCRIPTION
- new feature
- BC break? yes

In the case of obtaining a service for an Http Request in CLI mode, it does not make sense for the call method to be GET when no request exists.

I think Request should either throw an exception that cannot be used in a CLI context, or it should return a special CLI method.

Current behavior looks illogical:

![Screenshot from 2021-03-01 10-06-40](https://user-images.githubusercontent.com/4738758/109475802-6be79200-7a76-11eb-9964-298b0d9bdf79.png)

Thanks.