### PR TITLE
Session: fixed condition in destroy()

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -176,7 +176,7 @@ class Session
 	 */
 	public function destroy(): void
 	{
-		if (!session_status() === PHP_SESSION_ACTIVE) {
+		if (session_status() !== PHP_SESSION_ACTIVE) {
 			throw new Nette\InvalidStateException('Session is not started.');
 		}
 


### PR DESCRIPTION
- **bug fix**
- BC break? **no**

The condition has been always evaluated to `false` which led to `Warning: session_destroy(): Trying to destroy uninitialized session` instead of `InvalidStateException`.