### PR TITLE
FileUpload: support directory upload

### DIFF
--- a/src/Http/FileUpload.php
+++ b/src/Http/FileUpload.php
@@ -17,6 +17,7 @@ use Nette;
  *
  * @property-read string $name
  * @property-read string $sanitizedName
+ * @property-read string $untrustedFullPath
  * @property-read string|null $contentType
  * @property-read int $size
  * @property-read string $temporaryFile
@@ -31,6 +32,8 @@ final class FileUpload
 	public const IMAGE_MIME_TYPES = ['image/gif', 'image/png', 'image/jpeg', 'image/webp'];
 
 	private string $name;
+
+	private string|null $fullPath;
 
 	private string|false|null $type = null;
 
@@ -50,6 +53,7 @@ final class FileUpload
 			}
 		}
 		$this->name = $value['name'];
+		$this->fullPath = $value['full_path'] ?? null;
 		$this->size = $value['size'];
 		$this->tmpName = $value['tmp_name'];
 		$this->error = $value['error'];
@@ -91,6 +95,19 @@ final class FileUpload
 			$name .= '.' . ($this->getImageFileExtension() ?? 'unknown');
 		}
 		return $name;
+	}
+
+
+	/**
+	 * Returns the original full path as submitted by the browser during directory upload. Do not trust the value
+	 * returned by this method. A client could send a malicious directory structure with the intention to corrupt
+	 * or hack your application.
+	 *
+	 * The full path is only available in PHP 8.1 and above. In previous versions, this method returns the file name.
+	 */
+	public function getUntrustedFullPath(): string
+	{
+		return $this->fullPath ?? $this->name;
 	}
 
 

--- a/tests/Http/FileUpload.basic.phpt
+++ b/tests/Http/FileUpload.basic.phpt
@@ -16,6 +16,7 @@ require __DIR__ . '/../bootstrap.php';
 test('', function () {
 	$upload = new FileUpload([
 		'name' => 'readme.txt',
+		'full_path' => 'path/to/readme.txt',
 		'type' => 'text/plain',
 		'tmp_name' => __DIR__ . '/files/file.txt',
 		'error' => 0,
@@ -25,6 +26,7 @@ test('', function () {
 	Assert::same('readme.txt', $upload->getName());
 	Assert::same('readme.txt', $upload->getUntrustedName());
 	Assert::same('readme.txt', $upload->getSanitizedName());
+	Assert::same('path/to/readme.txt', $upload->getUntrustedFullPath());
 	Assert::same(209, $upload->getSize());
 	Assert::same(__DIR__ . '/files/file.txt', $upload->getTemporaryFile());
 	Assert::same(__DIR__ . '/files/file.txt', (string) $upload);
@@ -48,6 +50,7 @@ test('', function () {
 
 	Assert::same('../.image.png', $upload->getName());
 	Assert::same('image.png', $upload->getSanitizedName());
+	Assert::same('../.image.png', $upload->getUntrustedFullPath());
 	Assert::same('image/png', $upload->getContentType());
 	Assert::same('png', $upload->getImageFileExtension());
 	Assert::same([108, 46], $upload->getImageSize());


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: nette/docs#937

This adds support for directory upload / `full_path` metadata, added in PHP 8.1 (php/php-src#6917).