### PR TITLE
Request: Fix Referrer getter for malformed data + test

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -191,9 +191,16 @@ class Request implements IRequest
 	 */
 	public function getReferer(): ?UrlImmutable
 	{
-		return isset($this->headers['referer'])
-			? new UrlImmutable($this->headers['referer'])
-			: null;
+		if (!isset($this->headers['referer'])) {
+			return null;
+		}
+
+		try {
+			return new UrlImmutable($this->headers['referer']);
+		} catch (Nette\InvalidArgumentException $e) {
+			trigger_error("Unable to parse Malformed Referer URI: {$this->headers['referer']}");
+			return null;
+		}
 	}
 
 

--- a/tests/Http/Request.referer.phpt
+++ b/tests/Http/Request.referer.phpt
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test: Nette\Http\Request headers.
+ */
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('', function () {
+	$request = new Http\Request(new Http\UrlScript);
+
+	Assert::null($request->getReferer());
+});
+
+
+test('', function () {
+	$request = new Http\Request(new Http\UrlScript, null, null, null, [
+		'referer' => 'http://nette.org:8080/file.php?q=search',
+	]);
+
+	Assert::same('http://nette.org:8080/file.php?q=search', $request->getReferer()->getAbsoluteUrl());
+});
+
+
+test('', function () {
+	$request = new Http\Request(new Http\UrlScript, null, null, null, [
+		'referer' => '/////',
+	]);
+
+	Assert::error(function () use ($request) {
+		Assert::null($request->getReferer());
+	}, E_USER_NOTICE, 'Unable to parse Malformed Referer URI: /////');
+});


### PR DESCRIPTION
- bug fix
- BC break? no

## What problem is PR solving
Method `\Nette\Http\Request::getReferer()` throws `LogicException` when is called HTTP Request with malformed `Referer` header.

```shell
curl -v -H 'Referer://///' https://example.com/
```

```php
$httpRequest->getReferer();
// throws InvalidArgumentException: Malformed or unsupported URI '/////'.
```

It's wrong, because:

- Exception breaks Application stability according to 🔴 User's input,
- Exception is `Logic` type, but origin of error is only invalid user's input – developer here can't to prevent throw exception,
- Exception is throws too late, when developer call getter – until then it is Request object at incostistence,
- Developer does not except exception here (but be aware to just add `@throws`, it doesn't enough),
- Because Referer is nullable and because most usage of Referer value is logging of processed request, I suppose exception throwing is non-sense here. 

Normal use of Referer value is fo logging:

```php
$logger->logEvent($result, $id, (string)$request->url, $request->method, (string)$request->referer);
```

We can't to wrap whole row to `try/catch`, because it cause to skip log event. Developer must to separate getter call:

```php
try {
    $referer = (string)$request->referer;
}
catch(Nette\InvalidArgumentException $e) {
    $referer = null;
}

$logger->logEvent($result, $id, (string)$request->url, $request->method, $referer);
```

## What PR suggest

PR is suggesting to transmute Exception to Notice, return `null` and never throw Exception. 

Developer always can to read raw header by access through `$request->getHeader('Referer');`

## Security

Potentially this bug can be abused to intentionally bypassing log of user's activity, because in most cases is `Referer` value used for auditing done operations.