### PR TITLE
Request: Move Basic Auth credential from Url to Request due to prevent leak it

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -52,6 +52,10 @@ class Request implements IRequest
 	/** @var ?callable */
 	private $rawBodyCallback;
 
+	private ?string $user;
+
+	private ?string $password;
+
 
 	public function __construct(
 		UrlScript $url,
@@ -63,6 +67,8 @@ class Request implements IRequest
 		?string $remoteAddress = null,
 		?string $remoteHost = null,
 		?callable $rawBodyCallback = null,
+		?string $user = null,
+		?string $password = null,
 	) {
 		$this->url = $url;
 		$this->post = (array) $post;
@@ -73,6 +79,8 @@ class Request implements IRequest
 		$this->remoteAddress = $remoteAddress;
 		$this->remoteHost = $remoteHost;
 		$this->rawBodyCallback = $rawBodyCallback;
+		$this->user = $user;
+		$this->password = $password;
 	}
 
 
@@ -271,6 +279,18 @@ class Request implements IRequest
 	public function getRawBody(): ?string
 	{
 		return $this->rawBodyCallback ? ($this->rawBodyCallback)() : null;
+	}
+
+
+	public function getUser(): ?string
+	{
+		return $this->user;
+	}
+
+
+	public function getPassword(): ?string
+	{
+		return $this->password;
 	}
 
 

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -59,9 +59,9 @@ class RequestFactory
 		$url = new Url;
 		$this->getServer($url);
 		$this->getPathAndQuery($url);
-		$this->getUserAndPassword($url);
 		[$post, $cookies] = $this->getGetPostCookie($url);
 		[$remoteAddr, $remoteHost] = $this->getClient($url);
+		[$user, $password] = $this->getUserAndPassword();
 
 		return new Request(
 			new UrlScript($url, $this->getScriptPath($url)),
@@ -73,6 +73,8 @@ class RequestFactory
 			$remoteAddr,
 			$remoteHost,
 			fn(): string => file_get_contents('php://input'),
+			$user,
+			$password,
 		);
 	}
 
@@ -106,13 +108,6 @@ class RequestFactory
 		$path = Strings::fixEncoding(Strings::replace($path, $this->urlFilters['path']));
 		$url->setPath($path);
 		$url->setQuery($tmp[1] ?? '');
-	}
-
-
-	private function getUserAndPassword(Url $url): void
-	{
-		$url->setUser($_SERVER['PHP_AUTH_USER'] ?? '');
-		$url->setPassword($_SERVER['PHP_AUTH_PW'] ?? '');
 	}
 
 
@@ -287,6 +282,15 @@ class RequestFactory
 		}
 
 		return [$remoteAddr, $remoteHost];
+	}
+
+
+	private function getUserAndPassword(): array
+	{
+		$user = $_SERVER['PHP_AUTH_USER'] ?? null;
+		$password = $_SERVER['PHP_AUTH_PW'] ?? null;
+
+		return [$user, $password];
 	}
 
 

--- a/tests/Http/RequestFactory.userAndPassword.phpt
+++ b/tests/Http/RequestFactory.userAndPassword.phpt
@@ -18,11 +18,11 @@ $_SERVER = [
 	'PHP_AUTH_PW' => 'password',
 ];
 $factory = new RequestFactory;
-Assert::same('user', $factory->fromGlobals()->getUrl()->getUser());
-Assert::same('password', $factory->fromGlobals()->getUrl()->getPassword());
+Assert::same('user', $factory->fromGlobals()->getUser());
+Assert::same('password', $factory->fromGlobals()->getPassword());
 
 
 $_SERVER = [];
 $factory = new RequestFactory;
-Assert::same('', $factory->fromGlobals()->getUrl()->getUser());
-Assert::same('', $factory->fromGlobals()->getUrl()->getPassword());
+Assert::same(null, $factory->fromGlobals()->getUser());
+Assert::same(null, $factory->fromGlobals()->getPassword());


### PR DESCRIPTION
- new feature
- BC break? yes
- doc PR: nette/docs#932

Currently is too risky use `Url` object from from `Http\Request` created from global, because it can simply cause to leak user's credentials:

```php
echo $httpRequest->getUrl();

// https://example.com@username:password/index.php
```

The `Url` object already provide method `–>withoutUserInfo()` to remove user credential, but when programer forgot to use that, the credentials can leaks.

This PR ir removing user's credentials from `Url` object and move it to `Http\Request` directly.

It's based on czech discussion at Nette Forum: https://forum.nette.org/cs/33127-http-basic-login-http-url-nette-3-security-issue

I know, it's too naive PR, here is missing any way to notify developer the `Url->getUser()` no more get user from current request. This PR sent as initiation of change insecurity.