### PR TITLE
RequestFactory: support full_path

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -218,6 +218,7 @@ class RequestFactory
 					'name' => $v['name'][$k],
 					'type' => $v['type'][$k],
 					'size' => $v['size'][$k],
+					'full_path' => $v['full_path'][$k] ?? null,
 					'tmp_name' => $v['tmp_name'][$k],
 					'error' => $v['error'][$k],
 					'@' => &$v['@'][$k],

--- a/tests/Http/Request.files.directory.phpt
+++ b/tests/Http/Request.files.directory.phpt
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Test: Nette\Http\Request files.
+ */
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// Setup environment
+$_FILES = [
+	'files' => [
+		'name' => ['a.jpg', 'c.jpg'],
+		'type' => ['image/jpeg', 'image/jpeg'],
+		'full_path' => ['a.jpg', 'b/c.jpg'],
+		'tmp_name' => ['C:\\PHP\\temp\\php1D5D.tmp', 'C:\\PHP\\temp\\php1D5E.tmp'],
+		'error' => [0, 0],
+		'size' => [12345, 54321],
+	],
+];
+
+$factory = new Http\RequestFactory;
+$request = $factory->fromGlobals();
+
+Assert::type('array', $request->files['files']);
+Assert::count(2, $request->files['files']);
+Assert::type(Nette\Http\FileUpload::class, $request->files['files'][0]);
+Assert::type(Nette\Http\FileUpload::class, $request->files['files'][1]);
+
+Assert::same('a.jpg', $request->files['files'][0]->getUntrustedFullPath());
+Assert::same('b/c.jpg', $request->files['files'][1]->getUntrustedFullPath());


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: nette/docs#937

As a follow-up to #207, this adds support for correctly transforming directory uploads into FileUpload objects to RequestFactory.