### PR TITLE
SessionExtension: don't set readAndClose if null

### DIFF
--- a/src/Bridges/HttpDI/SessionExtension.php
+++ b/src/Bridges/HttpDI/SessionExtension.php
@@ -77,6 +77,10 @@ class SessionExtension extends Nette\DI\CompilerExtension
 		if ($config->autoStart === 'never') {
 			$options['autoStart'] = false;
 		}
+		
+		if ($config->readAndClose === null) {
+			unset($options['readAndClose']);
+		}
 
 		if (!empty($options)) {
 			$session->addSetup('setOptions', [$options]);


### PR DESCRIPTION
- bug fix (hopefully fix for https://forum.nette.org/cs/35361-cannot-configure-read-and-close-for-already-started-session)
- BC break? no

Session class throws exception if session is started and option read_and_close is set.
https://github.com/nette/http/blob/0679e7c51a76a2db1da0804b99c83eb3152d84b3/src/Http/Session.php#L401-L404

SessionExtension breaks compatibility with other session implementations (in case they already started the session) by always setting that option (to default value).
https://github.com/nette/http/blob/0679e7c51a76a2db1da0804b99c83eb3152d84b3/src/Bridges/HttpDI/SessionExtension.php#L40