### PR TITLE
RequestFactory: Optimize match proxy CIDR with remote IP

### DIFF
--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -280,7 +280,14 @@ class RequestFactory
 			: null;
 
 		// use real client address and host if trusted proxy is used
-		$usingTrustedProxy = $remoteAddr && array_filter($this->proxies, fn(string $proxy): bool => Helpers::ipMatch($remoteAddr, $proxy));
+		$usingTrustedProxy = false;
+		if ($remoteAddr) {
+			foreach ($this->proxies as $proxy) {
+				if ($usingTrustedProxy = Helpers::ipMatch($remoteAddr, $proxy)) {
+					break;
+				}
+			}
+		}
 		if ($usingTrustedProxy) {
 			empty($_SERVER['HTTP_FORWARDED'])
 				? $this->useNonstandardProxy($url, $remoteAddr, $remoteHost)


### PR DESCRIPTION
- BC break? no
- doc PR: not relevant

We are using CloudFlare reverse proxy to run production. [Cloudflare has proxy servers at 22 IP ranges](https://www.cloudflare.com/ips/). Nette `RequestFactory` is on **every** request must match user's IP with 22 CIDR IP masks.

https://github.com/nette/http/blob/4ca7b03d5726cf489f672a0e2a13178318a3d201/src/Http/RequestFactory.php#L283

⇧ this current construction is consuming unnecessarily much CPU/time, because:
- PHP is uneffective with call callback fuctions on loop ([read more about it](https://margaras.k47.cz/@k47/statuses/01GPZSGNYZ2NZWF354FAZHP19R) from @kaja47)
- Loop traversing is not lazy – it vainly continue in loop even have match.

Currently it's consuming about ~0.8 ms, that's ~1/10 of process whole request.

This PR suggest a little uglier but much faster constrictions which is up to:
- 20 × faster when matched (~0.04 ms),
- 4 × faster when unmatched (~0.2 ms).

No functionality changes.