### PR TITLE
Add DateTimeInterface to setCookie $expire param

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -307,7 +307,7 @@ Sets the expiration of the HTTP document using the `Cache-Control` and `Expires`
 $httpResponse->setExpiration('1 hour');
 ```
 
-setCookie(string $name, string $value, $time, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null, string $sameSite = null)
+setCookie(string $name, string $value, string|int|\DateTimeInterface|null $expire, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null, string $sameSite = null)
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sends a cookie. The default values ​​of the parameters are:
 - `$path` with scope to all directories (`'/'`)
@@ -316,7 +316,7 @@ Sends a cookie. The default values ​​of the parameters are:
 - `$httpOnly` is true, so the cookie is inaccessible to JavaScript
 - `$sameSite` is null, so the flag is not specified
 
-The time can be specified as a string or the number of seconds.
+The `$expire` parameter can be specified as a string, an object implementing `DateTimeInterface`, or the number of seconds.
 
 ```php
 $httpResponse->setCookie('lang', 'en', '100 days');

--- a/src/Http/IResponse.php
+++ b/src/Http/IResponse.php
@@ -397,7 +397,7 @@ interface IResponse
 	function setCookie(
 		string $name,
 		string $value,
-		?int $expire,
+		string|int|\DateTimeInterface|null $expire,
 		?string $path = null,
 		?string $domain = null,
 		?bool $secure = null,


### PR DESCRIPTION
Adds `string` and `DateTimeInterface` back to `setCookie` `$expire` param .

This is a fix for an undocumented (and possibly unwanted) BC break in 3.3.0.
In version 3.2.x and older, this was the type in the docblock.

Also fix the readme which had a wrong param name.

Close #233
