### PR TITLE
Session: keep exceptions chain on session_start

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -100,7 +100,7 @@ class Session
 				'session_start',
 				[['read_and_close' => $this->readAndClose]],
 				function (string $message) use (&$e): void {
-					$e = new Nette\InvalidStateException($message);
+					$e = new Nette\InvalidStateException($message, previous: $e);
 				},
 			);
 		} catch (\Throwable $e) {


### PR DESCRIPTION
- new feature
- BC break? no

There was an issue #208 - phpredis session driver was raising a notice, when session lock can't be obtained. Nette Session was correctly converting this notice to an exception. The strange was, that even the notice was raised, `session_start` returned `true` (it was phpredis problem).

Now, the new production version of phpredis is out, and the behavior is a little bit different. If a lock can't be obtained, instead of notice, the warning (instead of a notice) is raised and the `session_start` returned correctly `false`.

The problem is, I need to know the reason why the session wasn't started (when redis is death, it's a problem, when session lock can't be obtained, it's probably OK - user is probably doing many parallel requests). `Nette\Utils\Callback::invokeSafe` around the `session_start` method correctly converts warnings to exceptions, but now, there are two exceptions:
- the first is from the phpredis - something like `Failed to acquire session lock`
- the second is from the PHP itself `Failed to read session data: redis (path: tcp://server:6379?timeout=3&database=1&prefix=session:v1:)`

And the first one is overwritten with the second one, that is thrown to the app. But I need to know also the first one :-)

So my first idea is to set correct `previous` exception property and in the app, I have the complete exceptions chain, that I can read and get the correct session problem.
